### PR TITLE
Nested chained consumers

### DIFF
--- a/doc/reference/processors.rst
+++ b/doc/reference/processors.rst
@@ -202,6 +202,13 @@ stop
 .. autoclass:: Stopper
 
 
+.. _trap-failure:
+
+trap-failure
+^^^^^^^^^^^^
+.. autoclass:: TrapFailure
+
+
 .. _wait:
 
 wait

--- a/doc/topic/pipelines.rst
+++ b/doc/topic/pipelines.rst
@@ -29,6 +29,9 @@ Pipeline definitions
 Pipelines can be defined in multiple ways:
 
 
+
+.. _topic-pipelines-list:
+
 Using a :class:`list`
 """""""""""""""""""""
 
@@ -76,8 +79,8 @@ Each processor in the list will get the baton from the previous processor.
 .. _topic-pipelines-chained_consumers-rewriting:
 
 When using the list of processors or ``chained_consumers``, the pipeline definition is rewritten
-before the processors are instantiated. Every processor in a ``chained_consumers`` is appended to its
-preceding processors list of consumers.
+before the processors are instantiated. Every processor in a ``chained_consumers`` list is added to its
+preceeding processors list of consumers.
 
 This means the following two pipeline definitions are equivalent::
 
@@ -112,6 +115,55 @@ Which will be turned into the this processing graph:
     b -> d
     a -> e
     e -> f
+
+
+If both ``chained_consumers`` and ``consumers`` are defined, either explicitly (both keys being used in the configuration)
+or implicitly (processors inside a list of ``chained_consumers`` that define their own ``chained_consumers``). For example,
+consider the following pipeline definition:
+
+.. code-block:: yaml
+
+    my_pipeline:
+        - a
+            chained_consumers:
+                - b
+                - c
+        - d
+        - e
+
+Since the pipeline uses the shorthand syntax for ``chained_consumers`` (see :ref:`topic-pipelines-list`), all processors
+in the list is added to the precdeding processors list of consumers. Applying this once transforms the pipeline definition to this:
+
+.. code-block:: yaml
+
+    my_pipeline:
+        consumers:
+            - a:
+                chained_consumers:
+                    - b
+                    - c
+                consumers:
+                    - d:
+                        consumers:
+                            - e
+
+This process is done recursively for all the processors, and ``chained_consumers`` take precedence over ``consumers`` when it
+comes to the ordering of the consumers, which results in the following final pipeline, noting that ``b`` is the first consumer
+of ``a``:
+
+.. code-block:: yaml
+
+    my_pipeline:
+        consumers:
+            - a:
+                consumers:
+                    - b:
+                        consumers:
+                            - c
+                    - d:
+                        consumers:
+                            - e
+
 
 Inlining a pipeline
 """""""""""""""""""

--- a/doc/topic/pipelines.rst
+++ b/doc/topic/pipelines.rst
@@ -132,7 +132,7 @@ consider the following pipeline definition:
         - e
 
 Since the pipeline uses the shorthand syntax for ``chained_consumers`` (see :ref:`topic-pipelines-list`), all processors
-in the list is added to the precdeding processors list of consumers. Applying this once transforms the pipeline definition to this:
+in the list are added to the preceding processors list of consumers. Applying this once transforms the pipeline definition to this:
 
 .. code-block:: yaml
 
@@ -147,7 +147,7 @@ in the list is added to the precdeding processors list of consumers. Applying th
                         consumers:
                             - e
 
-This process is done recursively for all the processors, and ``chained_consumers`` take precedence over ``consumers`` when it
+This process is done recursively for all the processors, and ``chained_consumers`` takes precedence over ``consumers`` when it
 comes to the ordering of the consumers, which results in the following final pipeline, noting that ``b`` is the first consumer
 of ``a``:
 

--- a/piped/processing.py
+++ b/piped/processing.py
@@ -604,6 +604,9 @@ class ProcessorGraphFactory(object):
             base_name = chained_consumers_type.split('_',1)[-1]
             chained_consumers = pipeline.pop(chained_consumers_type, list())
 
+            # Make sure that any chained_consumers or chained_error_consumers becomes the first
+            # consumer of their parent processor by inserting them at the first position instead of
+            # appending them.
             if len(chained_consumers) == 1:
                 # Trivial case
                 pipeline.setdefault(base_name, []).insert(0, chained_consumers[0])

--- a/piped/test/test_processing.py
+++ b/piped/test/test_processing.py
@@ -1049,7 +1049,7 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         }
 
         # chained*_consumers should always become the first consumer if both chained*_consumers and consumers
-        # are defined
+        # are defined:
         expected_pipeline_configuration = {
             'a-pipeline': {
                 'consumers': [


### PR DESCRIPTION
Adds support for using chained_consumers and chained_error_consumers on arbitrarily nested processors.

For example:

```
stdin:
    pipeline: example

pipelines:
    example:
        - passthrough:
            chained_error_consumers:
                - trap-failure:
                    error_types: exceptions.Exception

                - existing: continuation

        - raise-exception

        - pretty-print:
            id: continuation
```

.. will result in pretty-print being executed, since the exception is handled. If both consumers and chained_consumers are defined, the chained_consumers will become the first consumer.
Would result in the pretty-print being executed.
