### PR TITLE
AMQP support

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -15,12 +15,14 @@ eggs = ${buildout:eggs}
 
 [piped-contrib]
 develop =
+    contrib/amqp
     contrib/database
     contrib/manhole
     contrib/status_testing
     contrib/validation
     contrib/zmq
 eggs =
+    piped.contrib.amqp
     piped.contrib.database
     piped.contrib.manhole
     piped.contrib.status_testing

--- a/contrib/amqp/piped/__init__.py
+++ b/contrib/amqp/piped/__init__.py
@@ -1,0 +1,13 @@
+# This is a namespace package.
+#
+# Setuptools would like us to use:
+#
+#    import pkg_resources
+#    pkg_resources.declare_namespace(__name__)
+#
+# But trial runs unit tests multiple times using this technique,
+# so we use the python built-in method of declaring a namespace
+# package instead (http://www.python.org/dev/peps/pep-0382/)
+
+import pkgutil
+__path__ = pkgutil.extend_path(__path__, __name__)

--- a/contrib/amqp/piped/contrib/__init__.py
+++ b/contrib/amqp/piped/contrib/__init__.py
@@ -1,0 +1,13 @@
+# This is a namespace package.
+#
+# Setuptools would like us to use:
+#
+#    import pkg_resources
+#    pkg_resources.declare_namespace(__name__)
+#
+# But trial runs unit tests multiple times using this technique,
+# so we use the python built-in method of declaring a namespace
+# package instead (http://www.python.org/dev/peps/pep-0382/)
+
+import pkgutil
+__path__ = pkgutil.extend_path(__path__, __name__)

--- a/contrib/amqp/piped/contrib/amqp/__init__.py
+++ b/contrib/amqp/piped/contrib/amqp/__init__.py
@@ -1,0 +1,3 @@
+# See http://www.python.org/dev/peps/pep-0386/ for version numbering, especially NormalizedVersion
+from distutils import version
+version = version.LooseVersion('0.2.0')

--- a/contrib/amqp/piped/contrib/amqp/providers.py
+++ b/contrib/amqp/piped/contrib/amqp/providers.py
@@ -1,0 +1,451 @@
+# Copyright (c) 2010-2011, Found IT A/S and Piped Project Contributors.
+# See LICENSE for details.
+import copy
+
+import pika
+from pika import connection, exceptions as pika_exceptions
+from pika.adapters import twisted_connection
+from zope import interface
+from twisted.application import service
+from twisted.internet import reactor, defer, task, endpoints, error
+from twisted.python import failure
+
+from piped import log, resource, util, event, exceptions
+
+
+class AMQPConnectionProvider(object, service.MultiService):
+    """ Provides AMQP connections.
+
+    Example:
+
+    .. code-block:: yaml
+
+        amqp:
+            connections:
+                connection_name:
+                    servers:
+                        - tcp:host=localhost:port=5672
+                    max_idle_time: 10 # reconnect if idle more than 10 seconds
+                    parameters:
+                        heartbeat: 3 # heartbeat every 3 seconds
+
+    The above configuration will result in a connected :class:`AMQProtocol` being
+    provided as ``amqp.connection.connection_name``.
+
+    See :class:`AMQPConnection` for more details on the configuration options.
+
+    """
+    interface.classProvides(resource.IResourceProvider)
+
+    def __init__(self):
+        self._connection_by_name = dict()
+        service.MultiService.__init__(self)
+
+    def configure(self, runtime_environment):
+        self.setServiceParent(runtime_environment.application)
+        
+        connections = runtime_environment.get_configuration_value('amqp.connections', dict())
+
+        for connection_name, connection_config in connections.items():
+            # basic consumers are handled by the AMQPConsumerProvider:
+            connection_config = copy.copy(connection_config)
+            connection_config.pop('basic_consumers', None)
+
+            connection = AMQPConnection(connection_name, **connection_config)
+            connection.setServiceParent(self)
+            self._connection_by_name[connection_name] = connection
+
+            logical_name = 'amqp.connection.{0}'.format(connection_name)
+
+            runtime_environment.resource_manager.register(logical_name, provider=self)
+
+    def add_consumer(self, resource_dependency):
+        name = resource_dependency.provider.rsplit('.', 1)[-1]
+        connection = self._connection_by_name[name]
+
+        connection.on_connected += resource_dependency.on_resource_ready
+        connection.on_disconnected += resource_dependency.on_resource_lost
+
+        if connection.ready:
+            resource_dependency.on_resource_ready(connection.protocol)
+
+
+class AMQProtocol(twisted_connection.TwistedProtocolConnection):
+    """ The AMQP protocol used by Piped. """
+
+    def __init__(self, parameters):
+        super(AMQProtocol, self).__init__(parameters)
+        self.on_lost = event.Event()
+
+        self._idle_state = (None, None)
+        self._named_channels = dict()
+        self._pending_named_channels = dict()
+        self.idle_checker = task.LoopingCall(self._check_idle)
+
+    def _adapter_disconnect(self):
+        super(AMQProtocol, self)._adapter_disconnect()
+        self._check_state_on_disconnect()
+
+    def connectionLost(self, reason):
+        self.on_lost(reason)
+        # stop the idle checker if it is running
+        self.idle_checker.stop() if self.idle_checker.running else None
+        return super(AMQProtocol, self).connectionLost(reason)
+
+    def _check_idle(self):
+        state = self.bytes_sent, self.bytes_received
+
+        if not state == self._idle_state:
+            self._idle_state = state
+            return
+
+        if self.connection_state not in (connection.CONNECTION_CLOSED, connection.CONNECTION_CLOSING):
+            self.close(320, 'Too long without data transferred.')
+            self.transport.loseConnection()
+
+    @defer.inlineCallbacks
+    def get_named_channel(self, channel_name):
+        """ Utility method that provides easy access to shared channels.
+
+        :param channel_name: A logical named used to identify the channel.
+        :return: A deferred that callbacks with the channel or errbacks with
+            a failure that describes the reason the channel is unavailable.
+        """
+        if channel_name in self._named_channels:
+            defer.returnValue(self._named_channels[channel_name])
+
+        if channel_name in self._pending_named_channels:
+            d = defer.Deferred()
+            self._pending_named_channels[channel_name] += d.callback
+            channel = yield d
+            defer.returnValue(channel)
+
+        self._pending_named_channels[channel_name] = pending_event = event.Event()
+
+        try:
+            self._named_channels[channel_name] = channel = yield self.channel()
+            channel.add_on_close_callback(lambda: self._named_channels.pop(channel_name, None))
+            pending_event(channel)
+            defer.returnValue(channel)
+        except Exception as e:
+            pending_event(failure.Failure())
+            raise
+        finally:
+            self._pending_named_channels.pop(channel_name, None)
+
+
+class AMQPConnection(object, service.MultiService):
+    """ AMQP connection wrapper. """
+    ready = False
+    protocol = None
+    _connecting = None
+    _reconnecting = None
+    bytes_sent = 0
+    bytes_received = 0
+
+    def __init__(self, name, servers, max_idle_time=None, reconnect_interval=1, parameters=None):
+        """
+        :param name: Logical name of the connection.
+        :param servers: List of endpoints to connect to. The endpoints are tried in a round-robin fashion.
+            See `twisted.internet.endpoints.clientFromString
+            <http://twistedmatrix.com/documents/current/api/twisted.internet.endpoints.html#clientFromString>`_
+            for details on the format.
+
+            Example: ``tcp:host=localhost:port=5672``
+
+        :param max_idle_time: The time (in seconds) the connection can be idle (not sending or receiving data)
+            before it is forcibly closed.
+        :param reconnect_interval: How long to sleep before reconnecting.
+        :param parameters: Used to create the connection parameters.
+            See the `pika documenation <http://pika.github.com/connecting.html#connection-parameters>`_.
+        """
+        service.MultiService.__init__(self)
+        
+        self.name = name
+        self.servers = servers
+        self._server_index = -1
+        self.reconnect_interval = reconnect_interval
+        
+        parameters = parameters or dict()
+        self.parameters = pika.ConnectionParameters(**parameters)
+
+        self.on_connected = event.Event()
+        self.on_disconnected = event.Event()
+
+        self.on_connected += lambda _: setattr(self, 'ready', True)
+        self.on_disconnected += lambda _: setattr(self, 'ready', False)
+        self.on_disconnected += lambda _: setattr(self, 'protocol', None)
+
+        self.max_idle_time = max_idle_time
+
+    def get_next_server(self):
+        self._server_index = (self._server_index+1)%len(self.servers)
+        return self.servers[self._server_index]
+
+    def configure(self, runtime_environment):
+        pass
+
+    def buildProtocol(self, transport):
+        protocol = AMQProtocol(self.parameters)
+        protocol.factory = self
+        return protocol
+
+    def startService(self):
+        if not self.running:
+            service.MultiService.startService(self)
+
+            self._keep_connecting()
+
+    @defer.inlineCallbacks
+    def stopService(self):
+        if self.running:
+            service.MultiService.stopService(self)
+            yield self._disconnect('stopping service')
+
+    @defer.inlineCallbacks
+    def _keep_connecting(self):
+        currently = util.create_deferred_state_watcher(self, '_reconnecting')
+        if self._reconnecting:
+            return
+
+        while self.running:
+            try:
+                server = self.get_next_server()
+                log.info('Connecting to {0}'.format(server))
+
+                endpoint = endpoints.clientFromString(reactor, server)
+
+                yield currently(self._connect(endpoint))
+
+            except defer.CancelledError as ce:
+                # the connection attempt might be cancelled, due to stopService/_disconnect
+                break
+
+            except (error.ConnectError, error.DNSLookupError, error.ConnectionDone) as ce:
+                # ConnectionDone might be raised because we managed to connect, but reached the
+                # max idle time during the AMQP handshake.
+                log.warn('Unable to connect: {0}'.format(repr(ce)))
+                self.on_disconnected(failure.Failure())
+                yield currently(util.wait(self.reconnect_interval))
+                continue
+
+            except Exception as e:
+                # log any completely unexpected errors, wait a little, then retry.
+                log.warn()
+                self.on_disconnected(failure.Failure())
+                yield currently(util.wait(self.reconnect_interval))
+                continue
+
+            else:
+                break
+
+    @defer.inlineCallbacks
+    def _connect(self, endpoint):
+        currently = util.create_deferred_state_watcher(self, '_connecting')
+        
+        # make sure we're not directly overwriting an existing protocol
+        if self.protocol:
+            if self.protocol.connection_state not in (connection.CONNECTION_CLOSED, connection.CONNECTION_CLOSING):
+                self._disconnect('reconnecting')
+
+        # once twisted has connected to the other side, we set our protocol
+        self.protocol = protocol = yield currently(endpoint.connect(self))
+        self.protocol.idle_checker.start(self.max_idle_time, now=False) if self.max_idle_time is not None else None
+
+        yield currently(self.protocol.ready)
+
+        self.on_connected(self.protocol)
+
+        def on_lost(reason):
+            protocol.on_lost -= on_lost
+            if self.protocol == protocol:
+                if protocol.idle_checker.running:
+                    protocol.idle_checker.stop()
+                # set the state to disconnected if we're still the current protocol
+                self.on_disconnected(reason)
+                # reconnect automatically if we're still supposed to be the current protocol
+                self._keep_connecting()
+                
+        self.protocol.on_lost += on_lost
+
+    def _disconnect(self, reason='unknown'):
+        if self._reconnecting:
+            self._reconnecting.cancel()
+        if self._connecting:
+            self._connecting.cancel()
+
+        if self.protocol:
+            if not self.protocol.connection_state in (connection.CONNECTION_CLOSED, connection.CONNECTION_CLOSING):
+                self.protocol.close(200, reason)
+
+            if self.protocol.idle_checker.running:
+                self.protocol.idle_checker.stop()
+
+        self.on_disconnected(reason)
+
+
+class AMQPConsumerProvider(object, service.MultiService):
+    """ Consumes message from AMQP queues.
+
+    Example configuration:
+
+    .. code-block:: yaml
+
+        amqp:
+            connections:
+                connection_name:
+                    basic_consumers:
+                        consumer_name:
+                            queue: name_of_queue_to_consume
+                            qos: # see http://www.rabbitmq.com/amqp-0-9-1-quickref.html#basic.qos
+                                prefetch_count: 200
+
+
+    See :class:`AMQPConsumer` for more details about available consumer configuration options.
+    """
+    interface.classProvides(resource.IResourceProvider)
+
+    def __init__(self):
+        self._consumer_by_name = dict()
+        service.MultiService.__init__(self)
+
+    def configure(self, runtime_environment):
+        self.setServiceParent(runtime_environment.application)
+
+        connection_configs = runtime_environment.get_configuration_value('amqp.connections', dict())
+
+        for connection_name, connection_config in connection_configs.items():
+            consumers = connection_config.get('basic_consumers', dict())
+
+            for consumer_name, consumer_config in consumers.items():
+                consumer = AMQPConsumer(name=consumer_name, connection=connection_name, **consumer_config)
+
+                consumer.configure(runtime_environment)
+                consumer.setServiceParent(self)
+
+                self._consumer_by_name[consumer_name] = consumer
+
+
+class AMQPConsumer(object, service.Service):
+    """ Consumes messages from an AMQP queue and processes them in a pipeline. """
+    _working = None
+
+    def __init__(self, name, pipeline, connection, queue=None, qos=None,
+        ack_before_processing=False, ack_after_successful_processing=True,
+        nack_after_failed_processing=True, channel_reopen_interval=1):
+        """
+        :param name: Logical name of this consumer.
+        :param pipeline: The pipeline used to process the messages.
+        :param connection: Name of the connection.
+        :param queue: Either a name (string) or a queue declaration (dict).
+            See `queue_declare <http://www.rabbitmq.com/amqp-0-9-1-quickref.html#queue.declare>`_.
+        :param qos: Used to specify the QOS on the channel.
+        :param ack_before_processing: If true, acks messages before they are processed.
+        :param ack_after_successful_processing: If true, acks messages if processing finishes
+            without errbacking.
+        :param nack_after_failed_processing: If true, rejects messages if processing errbacks.
+        :param channel_reopen_interval: Time (in seconds) to wait before reopening the consuming
+            channel if it closes.
+        """
+        self.name = name
+        self.pipeline_name = pipeline
+        self.connection_name = connection
+
+        if isinstance(queue, basestring):
+            queue = dict(queue=queue, passive=True)
+
+        self.queue_declare = queue or dict()
+        self.queue_declare.setdefault('queue', '')
+        self.queue_declare.setdefault('auto_delete', True)
+        self.queue_declare.setdefault('durable', False)
+
+        # default the queue to exclusive if the queue name is auto-generated
+        self.queue_declare.setdefault('exclusive', True if not self.queue_declare['queue'] else False)
+
+        self.qos = qos or dict()
+
+        self.ack_before_processing = ack_before_processing
+        self.ack_after_successful_processing = ack_after_successful_processing
+        self.nack_after_failed_processing = nack_after_failed_processing
+
+        if self.ack_before_processing and (self.ack_after_successful_processing or self.nack_after_failed_processing):
+            e_msg = 'Cannot both ack before processing and ack/nack after processing.'
+            raise exceptions.ConfigurationError(e_msg)
+
+        self.channel_reopen_interval = channel_reopen_interval
+
+    def configure(self, runtime_environment):
+        dm = runtime_environment.dependency_manager
+
+        self.dependency = dm.as_dependency(self)
+        self.dependency.on_ready += lambda _: self._run()
+        self.dependency.on_lost += lambda _, reason: self._stop_working()
+
+        self.pipeline_dependency = dm.add_dependency(self, dict(provider='pipeline.{0}'.format(self.pipeline_name)))
+        self.connection_dependency = dm.add_dependency(self, dict(provider='amqp.connection.{0}'.format(self.connection_name)))
+
+    def _stop_working(self):
+        if self._working:
+            self._working.cancel()
+
+    @defer.inlineCallbacks
+    def _run(self):
+        currently = util.create_deferred_state_watcher(self, '_working')
+        if self._working:
+            # we only need one worker :)
+            return
+
+        while self.running:
+            try:
+                connection = yield currently(self.connection_dependency.wait_for_resource())
+                channel = yield currently(connection.channel())
+
+                if self.qos:
+                    yield currently(channel.basic_qos(**self.qos))
+
+                frame = yield currently(channel.queue_declare(**self.queue_declare))
+                queue_name = frame.method.queue
+
+                queue, consumer_tag = yield currently(channel.basic_consume(queue=queue_name))
+
+                while self.running:
+                    channel, method, properties, body = yield currently(queue.get())
+
+                    if self.ack_before_processing:
+                        yield currently(channel.basic_ack(delivery_tag=method.delivery_tag))
+
+                    self._process(channel, method, properties, body)
+
+            except pika_exceptions.ChannelClosed as cc:
+                log.warn()
+                yield util.wait(self.channel_reopen_interval)
+
+            except Exception as e:
+                log.warn()
+
+    @defer.inlineCallbacks
+    def _process(self, channel, method, properties, body):
+        try:
+            yield self.process(channel=channel, method=method, properties=properties, body=body)
+        except Exception as e:
+            log.warn()
+            if self.nack_after_failed_processing:
+                yield channel.basic_reject(delivery_tag=method.delivery_tag)
+        else:
+            if self.ack_after_successful_processing:
+                yield channel.basic_ack(delivery_tag=method.delivery_tag)
+
+    @defer.inlineCallbacks
+    def process(self, **baton):
+        pipeline = yield self.pipeline_dependency.wait_for_resource()
+        yield pipeline.process(baton)
+
+    def startService(self):
+        if not self.running:
+            service.Service.startService(self)
+        if self.dependency.is_ready:
+            self._run()
+
+    def stopService(self):
+        service.Service.stopService(self)
+        self._stop_working()

--- a/contrib/amqp/piped/contrib/amqp/rpc.py
+++ b/contrib/amqp/piped/contrib/amqp/rpc.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2010-2011, Found IT A/S and Piped Project Contributors.
+# See LICENSE for details.
+from twisted.application import service
+from twisted.internet import defer
+from zope import interface
+from twisted.python import reflect
+
+from piped import log, resource, util, event
+
+
+class RPCClientProvider(object, service.MultiService):
+    """ Provides AMQP-based RPC clients.
+
+    Configuration example:
+
+    .. code-block:: yaml
+
+        amqp:
+            rpc_clients:
+                my_client:
+                    type: your_package.your_module.RPCClient
+                    consumer:
+                        queue:
+                            queue: explicit_queue_name
+                            exclusive: true
+
+    See :class:`RPCClientBase`, which may serve as an useful base-class.
+    """
+    interface.classProvides(resource.IResourceProvider)
+
+    def __init__(self):
+        service.MultiService.__init__(self)
+        self._client_by_name = dict()
+
+    def configure(self, runtime_environment):
+        self.setServiceParent(runtime_environment.application)
+        self.runtime_environment = runtime_environment
+        self.dependency_manager = runtime_environment.dependency_manager
+
+        self.clients = runtime_environment.get_configuration_value('amqp.rpc_clients', dict())
+        resource_manager = runtime_environment.resource_manager
+
+        for client_name, client_configuration in self.clients.items():
+            resource_manager.register('amqp.rpc_client.{0}'.format(client_name), provider=self)
+
+            self._get_or_create_client(client_name)
+
+    def _get_or_create_client(self, client_name):
+        if client_name not in self._client_by_name:
+            client_configuration = self.clients[client_name]
+            type = client_configuration.pop('type', reflect.fullyQualifiedName(RPCClientBase))
+            client = reflect.namedAny(type)(client_name, **client_configuration)
+            client.configure(self.runtime_environment)
+            client.setServiceParent(self)
+
+            self._client_by_name[client_name] = client
+        return self._client_by_name[client_name]
+
+    def add_consumer(self, resource_dependency):
+        client_name = resource_dependency.provider.rsplit('.', 1)[-1]
+        client = self._get_or_create_client(client_name)
+        client_dependency = self.dependency_manager.as_dependency(client)
+
+        client_dependency.on_ready += lambda dep: resource_dependency.on_resource_ready(dep.get_resource())
+        client_dependency.on_lost += lambda dep, reason: resource_dependency.on_resource_lost(reason)
+
+        if client_dependency.is_ready:
+            resource_dependency.on_resource_ready(client)
+
+
+class RPCClientBase(object, service.Service):
+    """ Base class for RPC client implementations.
+
+    """
+    connection = None
+    consume_channel = None
+    response_queue = None
+    publish_channel = None
+    pending_publish_channel = None
+
+    _starting = None
+    _consuming = None
+
+    def __init__(self, name, connection, consumer=None):
+        """
+        :param name: Logical name of this rpc client.
+        :param connection: Name of the AMQP connection.
+        :param consumer: Configuration options for the consuming:
+            
+            no_ack
+                Whether the server should require the consumer to ack the responses. Defaults to false.
+
+            queue
+                Name of the response queue (string) or a queue declaration (dict). Defaults to
+                the empty string, which creates an anonymous queue.
+                See `queue_declare <http://www.rabbitmq.com/amqp-0-9-1-quickref.html#queue.declare>`_.
+        """
+        self.name = name
+        self.connection_name = connection
+        self.consumer_config = consumer or dict()
+        
+        response_queue = self.consumer_config.get('queue', None)
+        if isinstance(response_queue, basestring):
+            response_queue = dict(queue=response_queue)
+
+        self.response_queue_declare = response_queue or dict()
+        self.response_queue_declare.setdefault('queue', '')
+        self.response_queue_declare.setdefault('auto_delete', True)
+        self.response_queue_declare.setdefault('durable', False)
+        self.response_queue_declare.setdefault('exclusive', True)
+
+        self.requests = dict()
+        self.on_connection_lost = event.Event()
+        self.on_connection_lost += lambda reason: self._handle_disconnect()
+
+    def configure(self, runtime_environment):
+        self.runtime_environment = runtime_environment
+        self.dependency_manager = self.runtime_environment.dependency_manager
+        dm = self.dependency_manager
+
+        self.dependency = dm.as_dependency(self)
+        self.dependency.cascade_ready = False
+        self.dependency.on_dependency_ready += lambda dependency: self._consider_starting()
+
+        self.connection_dependency = dm.add_dependency(self, dict(provider='amqp.connection.{0}'.format(self.connection_name)))
+        self.connection_dependency.on_lost += lambda dep, reason: self.on_connection_lost(reason)
+
+    @defer.inlineCallbacks
+    def _consider_starting(self):
+        currently = util.create_deferred_state_watcher(self, '_starting')
+
+        if not self.dependency_manager.has_all_dependencies_provided(self.dependency):
+            return
+
+        if not self.running or self._starting:
+            return
+
+        try:
+            if not self.connection:
+                self.connection = yield currently(self.connection_dependency.wait_for_resource())
+            if not self.consume_channel:
+                self.consume_channel = yield currently(self.connection.channel())
+            if not self.response_queue:
+                self.response_queue = yield currently(self.consume_channel.queue_declare(**self.response_queue_declare))
+
+            self._consume_queue()
+        except defer.CancelledError as ce:
+            log.info('Initialization of %r was cancelled.' % self)
+
+    def _handle_disconnect(self):
+        self.connection = None
+        self.consume_channel = None
+        self.response_queue = None
+
+        # cancel any current operations
+        for current_operation in (self._starting, self._consuming):
+            if current_operation:
+                current_operation.cancel()
+
+    def startService(self):
+        service.Service.startService(self)
+        self._consider_starting()
+
+    def stopService(self):
+        service.Service.stopService(self)
+        
+        for current_operation in (self._starting, self._consuming):
+            if current_operation:
+                current_operation.cancel()
+
+        self.dependency.fire_on_lost('stopping client')
+
+    @defer.inlineCallbacks
+    def _consume_queue(self):
+        currently = util.create_deferred_state_watcher(self, '_consuming')
+        
+        queue, consumer_tag = yield currently(self.consume_channel.basic_consume(queue=self.response_queue.method.queue, no_ack=self.consumer_config.get('no_ack', True), exclusive=self.response_queue_declare['exclusive']))
+        if self.running:
+            self.dependency.fire_on_ready()
+        try:
+            while self.dependency.is_ready and self.running:
+                channel, method, properties, body = yield currently(queue.get())
+                d = defer.maybeDeferred(self.process_response, channel, method, properties, body)
+        except defer.CancelledError as ce:
+            return
+
+    def process_response(self, channel, method, properties, body):
+        raise NotImplementedError()

--- a/contrib/amqp/piped/contrib/amqp/test/test_providers.py
+++ b/contrib/amqp/piped/contrib/amqp/test/test_providers.py
@@ -1,0 +1,550 @@
+# Copyright (c) 2010-2011, Found IT A/S and Piped Project Contributors.
+# See LICENSE for details.
+
+import mock
+from mock import patch
+from pika import frame, exceptions as pika_exceptions
+from twisted.application import service
+from twisted.python import failure
+from twisted.trial import unittest
+from twisted.internet import defer, error
+
+from piped import util, processing, dependencies, exceptions, event
+from piped.contrib.amqp import providers
+
+
+class TestConnectionProvider(unittest.TestCase):
+    def setUp(self):
+        self.runtime_environment = processing.RuntimeEnvironment()
+        self.runtime_environment.application = service.MultiService()
+        self.runtime_environment.configure()
+
+    def tearDown(self):
+        self.runtime_environment.application.stopService()
+
+    def test_provided_connections(self):
+        cm = self.runtime_environment.configuration_manager
+        cm.set('amqp.connections.test_connection', dict(
+            servers = ['tcp:host=localhost:port=5672'],
+            max_idle_time = 10,
+            reconnect_interval = 5,
+            parameters = dict(
+                heartbeat = 3
+            )
+        ))
+
+        provider = providers.AMQPConnectionProvider()
+        provider.configure(self.runtime_environment)
+
+        connection_dependency = dependencies.ResourceDependency(provider='amqp.connection.test_connection')
+        self.runtime_environment.resource_manager.resolve(connection_dependency)
+
+        with patch.object(providers.endpoints, 'clientFromString') as mocked_client_from_string:
+            def connect(factory):
+                protocol = factory.buildProtocol(None)
+                protocol.transport = mock.Mock()
+                # mark the protocol as ready
+                protocol.connectionReady(protocol)
+                return protocol
+
+            mocked_client_from_string.return_value.connect.side_effect = connect
+            provider.startService()
+
+            connection = connection_dependency.get_resource()
+            self.assertIsInstance(connection, providers.AMQProtocol)
+
+            self.assertEquals(connection.factory.servers, cm.get('amqp.connections.test_connection.servers'))
+            self.assertEquals(connection.factory.reconnect_interval, cm.get('amqp.connections.test_connection.reconnect_interval'))
+            self.assertEquals(connection.idle_checker.interval, cm.get('amqp.connections.test_connection.max_idle_time'))
+            self.assertEquals(connection.parameters.heartbeat, cm.get('amqp.connections.test_connection.parameters.heartbeat'))
+
+        # if another dependency asks for the same connection, it should receive the same instance
+        another_connection_dependency = dependencies.ResourceDependency(provider='amqp.connection.test_connection')
+        self.runtime_environment.resource_manager.resolve(another_connection_dependency)
+
+        self.assertIdentical(another_connection_dependency.get_resource(), connection_dependency.get_resource())
+
+
+class TestMockConnection(unittest.TestCase):
+
+    def setUp(self):
+        self.service = service.MultiService()
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.service.stopService()
+
+    @defer.inlineCallbacks
+    def test_get_named_channels(self):
+        connection = providers.AMQPConnection('test_name', servers=['tcp:host=server_1:port=5672'])
+        connection.setServiceParent(self.service)
+
+        with patch.object(providers.endpoints, 'clientFromString') as mocked_client_from_string:
+            def connect(factory):
+                protocol = factory.buildProtocol(None)
+                protocol.transport = mock.Mock()
+                # mark the protocol as ready
+                protocol.connectionReady(protocol)
+                return protocol
+
+            mocked_client_from_string.return_value.connect.side_effect = connect
+            connection.startService()
+
+            # the connection should now be finished connecting:
+            self.assertTrue(connection.ready)
+
+            protocol = connection.protocol
+
+            channel_requests = list()
+            with patch.object(protocol, 'channel') as mocked_channel:
+                def channel():
+                    d = defer.Deferred()
+                    channel_requests.append(d)
+                    return d
+
+                mocked_channel.side_effect = channel
+
+                foo_1_d = protocol.get_named_channel('foo')
+                foo_2_d = protocol.get_named_channel('foo')
+                foo_3_d = protocol.get_named_channel('foo')
+
+                bar_d = protocol.get_named_channel('bar')
+
+                self.assertEquals(len(channel_requests), 2)
+
+                mocked_foo = mock.Mock()
+                mocked_foo_close = event.Event()
+                mocked_foo.add_on_close_callback.side_effect = mocked_foo_close.handle
+                mocked_bar = mock.Mock()
+
+                channel_requests.pop(0).callback(mocked_foo)
+                channel_requests.pop(0).callback(mocked_bar)
+
+                # all the pending requests for the channel should receive the same instance
+                foo = yield defer.DeferredList([foo_1_d, foo_2_d, foo_3_d])
+                self.assertEquals(set(foo), set([(True, mocked_foo)]))
+
+                bar = yield bar_d
+                self.assertEquals(bar, mocked_bar)
+
+                self.assertEquals(len(channel_requests), 0)
+                another_foo = yield protocol.get_named_channel('foo')
+                self.assertEquals(len(channel_requests), 0)
+
+                # if the channel is closed, the next request to get the channel will recreate it
+                mocked_foo_close()
+                self.assertEquals(len(channel_requests), 0)
+                new_foo = protocol.get_named_channel('foo')
+                self.assertEquals(len(channel_requests), 1)
+
+                # if the channel request errbacks, all pending requests for the named channel should errback
+                new_foo_2 = protocol.get_named_channel('foo')
+                test_exception = Exception()
+                channel_requests.pop(0).callback(failure.Failure(test_exception))
+
+                for pending_foo in (new_foo, new_foo_2):
+                    try:
+                        yield pending_foo
+                        self.fail('Expected {0!r} to be raised.'.format(new_foo))
+                    except Exception as e:
+                        self.assertEquals(e, test_exception)
+
+
+    def test_connect_disconnect_when_service_starts_stops(self):
+        connection = providers.AMQPConnection('test_name', servers=['tcp:host=localhost:port=5672'])
+
+        with patch.object(connection, '_connect') as mocked_connect:
+            def verify(endpoint):
+                self.assertEquals(endpoint._host, 'localhost')
+                self.assertEquals(endpoint._port, 5672)
+
+            mocked_connect.side_effect = verify
+            connection.startService()
+
+            mocked_connect.assert_called_once()
+
+        with patch.object(connection, '_disconnect') as mocked_disconnect:
+            connection.stopService()
+
+            mocked_disconnect.assert_called_once_with('stopping service')
+
+    @defer.inlineCallbacks
+    def test_reconnect_if_connect_fails(self):
+        connection = providers.AMQPConnection('test_name', servers=['tcp:host=server_1:port=5672', 'tcp:host=server_2:port=5673'], reconnect_interval=0)
+        connection.setServiceParent(self.service)
+
+        endpoints = list()
+        connect_return_values = [error.ConnectError('test_error'), error.DNSLookupError('test_error'), error.ConnectionDone('test_error')]
+        expected_errors = list(connect_return_values)
+
+        disconnects = list()
+        connection.on_disconnected += disconnects.append
+
+        with patch.object(connection, '_connect') as mocked_connect:
+            def verify(endpoint):
+                endpoints.append(dict(host=endpoint._host, port=endpoint._port))
+                raise connect_return_values.pop(0)
+
+            mocked_connect.side_effect = verify
+
+            with patch.object(providers.log, 'warn') as mocked_warn:
+                connection.startService()
+                while connect_return_values:
+                    yield util.wait(0)
+
+                self.assertEquals(mocked_warn.call_count, len(expected_errors))
+
+            # the servers should be attempted in a round-robin fashion:
+            server_1 = dict(host='server_1', port=5672)
+            server_2 = dict(host='server_2', port=5673)
+            self.assertEquals(endpoints, [server_1, server_2, server_1])
+
+            # all our expected errors should be seen as reasons for disconnects:
+            errors = [disconnect.value for disconnect in disconnects]
+            self.assertEquals(errors, expected_errors)
+
+    def test_reconnect_on_connection_lost(self):
+        connection = providers.AMQPConnection('test_name', servers=['tcp:host=server_1:port=5672'])
+        connection.setServiceParent(self.service)
+
+        # store the connected/disconnected events
+        events = list()
+        connection.on_connected += events.append
+        connection.on_disconnected += events.append
+
+        with patch.object(providers.endpoints, 'clientFromString') as mocked_client_from_string:
+            def connect(factory):
+                protocol = factory.buildProtocol(None)
+                protocol.transport = mock.Mock()
+                # mark the protocol as ready
+                protocol.connectionReady(protocol)
+                return protocol
+
+            mocked_client_from_string.return_value.connect.side_effect = connect
+            connection.startService()
+
+            # the connection should now be finished connecting:
+            self.assertTrue(connection.ready)
+            self.assertEquals(connection._connecting, None)
+            self.assertEquals(connection._reconnecting, None)
+
+            # tell the protocol the connection has been lost
+            previous_protocol = connection.protocol
+            previous_protocol.connectionLost('testing lost')
+
+            # the connection will be retried immediately:
+            self.assertTrue(connection.ready)
+            self.assertEquals(connection._connecting, None)
+            self.assertEquals(connection._reconnecting, None)
+
+            # the connection should now be using a new protocol
+            self.assertNotEquals(previous_protocol, connection.protocol)
+
+            self.assertEquals(events, [previous_protocol, 'testing lost', connection.protocol])
+
+    @defer.inlineCallbacks
+    def test_idle_connections_are_disconnected(self):
+        # create a connection with max_idle_time set to 0, which means that data must be sent or received every reactor iteration.
+        connection = providers.AMQPConnection('test_name', servers=['tcp:host=server_1:port=5672'], max_idle_time=0)
+        connection.setServiceParent(self.service)
+
+        # store the connected/disconnected events
+        events = list()
+        connection.on_connected += events.append
+        connection.on_disconnected += events.append
+
+        with patch.object(providers.endpoints, 'clientFromString') as mocked_client_from_string:
+            created_protocols = defer.DeferredQueue()
+            def connect(factory):
+                protocol = factory.buildProtocol(None)
+                protocol.transport = mock.Mock()
+                protocol.transport.loseConnection.side_effect = lambda: protocol.connectionLost('test lost connection')
+
+                created_protocols.put(protocol)
+
+                protocol.connectionReady('test ready')
+                return protocol
+
+            mocked_client_from_string.return_value.connect.side_effect = connect
+            connection.startService()
+
+            # protocols 1 and 2 gets disconnected by the idle checker, and we will examine protocol 3 closer:
+            protocol_1 = yield created_protocols.get()
+            protocol_2 = yield created_protocols.get()
+            protocol_3 = yield created_protocols.get()
+
+            # wait one reactor iteration for the connection to start using the third protocol
+            yield util.wait(0)
+
+            # the third attempt has not resulted in an on_connection() event yet
+            self.assertEquals(events, [protocol_1, 'test lost connection', protocol_2, 'test lost connection', protocol_3])
+            events[:] = list()
+
+            # send a heartbeat frame every reactor iteration in order to pretend that data is being transferred
+            for i in range(10):
+                protocol_3._send_frame(frame.Heartbeat())
+                yield util.wait(0)
+
+            # since the protocol haven't been idle, it should still be used by the connection
+            self.assertEquals(events, list())
+            self.assertEquals(created_protocols.pending, list())
+
+            # .. but if we stop manually bumping the received bytes count, it should die:
+            yield util.wait(0)
+
+            # .. which causes a new protocol to be created immediately
+            self.assertEquals(len(created_protocols.pending), 1)
+            self.assertEquals(events, ['test lost connection', created_protocols.pending[0]])
+
+
+class TestConsumerProvider(unittest.TestCase):
+    def setUp(self):
+        self.runtime_environment = processing.RuntimeEnvironment()
+        self.runtime_environment.application = service.MultiService()
+        self.runtime_environment.configure()
+
+    def tearDown(self):
+        self.runtime_environment.application.stopService()
+
+    def test_consumer_created(self):
+        cm = self.runtime_environment.configuration_manager
+        cm.set('amqp.connections.bar.basic_consumers.test_consumer', dict(
+            pipeline = 'foo'
+        ))
+        provider = providers.AMQPConsumerProvider()
+
+        with patch.object(providers, 'AMQPConsumer') as mock_consumer_class:
+            provider.configure(self.runtime_environment)
+            mock_consumer_class.assert_called_once_with(name='test_consumer', pipeline='foo', connection='bar')
+
+
+class TestConsumer(unittest.TestCase):
+    def setUp(self):
+        self.runtime_environment = processing.RuntimeEnvironment()
+        self.runtime_environment.application = service.MultiService()
+        self.runtime_environment.configure()
+
+    def tearDown(self):
+        self.runtime_environment.application.stopService()
+
+    def _create_consumer(self, **consumer_config):
+        dm = self.runtime_environment.dependency_manager
+        consumer = providers.AMQPConsumer('test consumer', **consumer_config)
+        consumer.configure(self.runtime_environment)
+        # set the dependencies as resolved, so their events (ready/etc) are propagated
+        dm._dependency_graph.node[consumer.dependency]['resolved'] = True
+        dm._dependency_graph.node[consumer.pipeline_dependency]['resolved'] = True
+        dm._dependency_graph.node[consumer.connection_dependency]['resolved'] = True
+        return consumer
+
+    def test_queue_declaration(self):
+        # Anonymous queues are exclusive by default
+        consumer = self._create_consumer(
+            pipeline='p', connection='c'
+        )
+        self.assertEquals(consumer.queue_declare['queue'], '')
+        self.assertEquals(consumer.queue_declare['exclusive'], True)
+
+        # queues can be a simple string-named queue, which means it
+        # should be passive
+        consumer = self._create_consumer(
+            pipeline='p', connection='c',
+            queue = 'foo'
+        )
+        self.assertEquals(consumer.queue_declare['queue'], 'foo')
+        self.assertEquals(consumer.queue_declare['exclusive'], False)
+
+        # we can use a dict to be more explicit about the queue configuration.
+        consumer = self._create_consumer(
+            pipeline='p', connection='c',
+            queue = dict(
+                queue = 'bar',
+                exclusive = True
+            )
+        )
+        self.assertEquals(consumer.queue_declare['queue'], 'bar')
+        self.assertEquals(consumer.queue_declare['exclusive'], True)
+
+    def test_invalid_configurations(self):
+        self.assertRaises(exceptions.ConfigurationError, self._create_consumer,
+            pipeline='p', connection='c',
+            ack_before_processing = True,
+            ack_after_successful_processing = True,
+            nack_after_failed_processing = True
+        )
+
+        self.assertRaises(exceptions.ConfigurationError, self._create_consumer,
+            pipeline='p', connection='c',
+            ack_before_processing = True,
+            ack_after_successful_processing = False,
+            nack_after_failed_processing = True
+        )
+
+        self.assertRaises(exceptions.ConfigurationError, self._create_consumer,
+            pipeline='p', connection='c',
+            ack_before_processing = True,
+            ack_after_successful_processing = True,
+            nack_after_failed_processing = False
+        )
+
+    def test_messages_are_delivered_to_pipelines(self):
+        consumer = self._create_consumer(pipeline='test_pipeline', connection='test_connection', qos=dict(prefetch_count=4))
+        consumer.startService()
+
+        mocked_pipeline = mock.Mock(name='pipeline')
+        consumer.pipeline_dependency.on_resource_ready(mocked_pipeline)
+
+        message_queue = defer.DeferredQueue()
+        mocked_connection = mock.Mock(name='connection')
+        mocked_channel = mocked_connection.channel.return_value = mock.Mock(name='channel')
+        mocked_consumer_tag = mock.Mock(name='consumer_tag')
+        mocked_channel.basic_consume.return_value = message_queue, mocked_consumer_tag
+
+        consumer.connection_dependency.on_resource_ready(mocked_connection)
+
+        mocked_channel.basic_qos.assert_called_once_with(prefetch_count=4)
+
+        # no messages have entered the queue yet:
+        self.assertEquals(mocked_pipeline.process.call_count, 0)
+
+        # but putting message into the queue should result in the pipeline being invoked
+        message_queue.put((mocked_channel, mock.Mock(name='method'), mock.Mock(name='properties'), 'test message body'))
+        self.assertEquals(mocked_pipeline.process.call_count, 1)
+
+        # call_args_list is a list of (args, kwargs) tuples, and the baton is the first element in the argument
+        baton = mocked_pipeline.process.call_args_list[0][0][0]
+
+        self.assertEquals(baton['channel'], mocked_channel)
+        self.assertEquals(baton['method']._name, 'method')
+        self.assertEquals(baton['properties']._name, 'properties')
+        self.assertEquals(baton['body'], 'test message body')
+
+        # since the processing worked, the message should have been acked
+        mocked_channel.basic_ack.assert_called_once_with(delivery_tag=baton['method'].delivery_tag)
+
+    def test_messages_are_delivered_to_pipelines_after_restarting(self):
+        consumer = self._create_consumer(pipeline='test_pipeline', connection='test_connection')
+        consumer.startService()
+
+        mocked_pipeline = mock.Mock(name='pipeline')
+        consumer.pipeline_dependency.on_resource_ready(mocked_pipeline)
+
+        message_queue = defer.DeferredQueue()
+        mocked_connection = mock.Mock(name='connection')
+        mocked_channel = mocked_connection.channel.return_value = mock.Mock(name='channel')
+        mocked_consumer_tag = mock.Mock(name='consumer_tag')
+        mocked_channel.basic_consume.return_value = message_queue, mocked_consumer_tag
+
+        consumer.connection_dependency.on_resource_ready(mocked_connection)
+
+        self.assertEquals(mocked_pipeline.process.call_count, 0)
+        message_queue.put((mocked_channel, mock.Mock(name='method'), mock.Mock(name='properties'), 'test message body'))
+        self.assertEquals(mocked_pipeline.process.call_count, 1)
+
+        with patch.object(providers.log, 'warn') as mocked_warn:
+            consumer.stopService()
+            consumer.startService()
+
+        # but putting message into the queue should result in the pipeline being invoked
+        self.assertEquals(mocked_pipeline.process.call_count, 1)
+        message_queue.put((mocked_channel, mock.Mock(name='method'), mock.Mock(name='properties'), 'test message body'))
+        self.assertEquals(mocked_pipeline.process.call_count, 2)
+
+    @defer.inlineCallbacks
+    def test_channels_are_reopened(self):
+        # reopen channels after one reactor iteration
+        consumer = self._create_consumer(pipeline='test_pipeline', connection='test_connection', channel_reopen_interval=0)
+        consumer.startService()
+
+        mocked_pipeline = mock.Mock(name='pipeline')
+        consumer.pipeline_dependency.on_resource_ready(mocked_pipeline)
+
+        # mock the queue so we can fake a closed channel
+        message_queue = defer.DeferredQueue()
+        mocked_connection = mock.Mock(name='connection')
+        mocked_channel = mocked_connection.channel.return_value = mock.Mock(name='channel')
+        mocked_consumer_tag = mock.Mock(name='consumer_tag')
+        mocked_channel.basic_consume.return_value = message_queue, mocked_consumer_tag
+
+        consumer.connection_dependency.on_resource_ready(mocked_connection)
+
+        self.assertEquals(mocked_pipeline.process.call_count, 0)
+        message_queue.put((mocked_channel, mock.Mock(name='method'), mock.Mock(name='properties'), 'test message body'))
+        self.assertEquals(mocked_pipeline.process.call_count, 1)
+
+        # only one channel should have been created at the moment
+        self.assertEquals(mocked_connection.channel.call_count, 1)
+
+        with patch.object(providers.log, 'warn') as mocked_warn:
+            message_queue.put(failure.Failure(pika_exceptions.ChannelClosed()))
+
+        # wait for the reopen interval to pass:
+        yield util.wait(0)
+        # now, a second channel should have been made
+        self.assertEquals(mocked_connection.channel.call_count, 2)
+
+        self.assertEquals(mocked_pipeline.process.call_count, 1)
+        message_queue.put((mocked_channel, mock.Mock(name='method'), mock.Mock(name='properties'), 'test message body'))
+        self.assertEquals(mocked_pipeline.process.call_count, 2)
+
+    def test_message_nacking_on_failed_processing(self):
+        consumer = self._create_consumer(pipeline='test_pipeline', connection='test_connection')
+        consumer.startService()
+
+        mocked_pipeline = mock.Mock(name='pipeline')
+        consumer.pipeline_dependency.on_resource_ready(mocked_pipeline)
+
+        message_queue = defer.DeferredQueue()
+        mocked_connection = mock.Mock(name='connection')
+        mocked_channel = mocked_connection.channel.return_value = mock.Mock(name='channel')
+        mocked_consumer_tag = mock.Mock(name='consumer_tag')
+        mocked_channel.basic_consume.return_value = message_queue, mocked_consumer_tag
+
+        consumer.connection_dependency.on_resource_ready(mocked_connection)
+
+        # no messages have entered the queue yet:
+        self.assertEquals(mocked_pipeline.process.call_count, 0)
+
+        def raiser(baton):
+            raise Exception('test exception')
+
+        mocked_pipeline.process.side_effect = raiser
+
+        # but putting message into the queue should result in the pipeline being invoked
+        with patch.object(providers.log, 'warn') as mocked_warn:
+            mocked_method = mock.Mock(name='method')
+            message_queue.put((mocked_channel, mocked_method, mock.Mock(name='properties'), 'test message body'))
+        
+        self.assertEquals(mocked_pipeline.process.call_count, 1)
+        
+        # since the processing raised an exception, the message should have been rejected
+        mocked_channel.basic_reject.assert_called_once_with(delivery_tag=mocked_method.delivery_tag)
+
+    def test_message_acking_before_processing(self):
+        consumer = self._create_consumer(pipeline='test_pipeline', connection='test_connection',
+            ack_before_processing=True, ack_after_successful_processing=False,
+            nack_after_failed_processing=False)
+        consumer.startService()
+
+        mocked_pipeline = mock.Mock(name='pipeline')
+        consumer.pipeline_dependency.on_resource_ready(mocked_pipeline)
+
+        message_queue = defer.DeferredQueue()
+        mocked_connection = mock.Mock(name='connection')
+        mocked_channel = mocked_connection.channel.return_value = mock.Mock(name='channel')
+        mocked_consumer_tag = mock.Mock(name='consumer_tag')
+        mocked_channel.basic_consume.return_value = message_queue, mocked_consumer_tag
+
+        consumer.connection_dependency.on_resource_ready(mocked_connection)
+
+        # return a deferred that never fires
+        mocked_pipeline.process.return_value = defer.Deferred()
+
+        with patch.object(providers.log, 'warn') as mocked_warn:
+            mocked_method = mock.Mock(name='method')
+            message_queue.put((mocked_channel, mocked_method, mock.Mock(name='properties'), 'test message body'))
+
+        self.assertEquals(mocked_pipeline.process.call_count, 1)
+
+        # the message should be acked even if we're not done processing it
+        mocked_channel.basic_ack.assert_called_once_with(delivery_tag=mocked_method.delivery_tag)

--- a/contrib/amqp/piped/contrib/amqp/test/test_providers.py
+++ b/contrib/amqp/piped/contrib/amqp/test/test_providers.py
@@ -183,7 +183,7 @@ class TestMockConnection(unittest.TestCase):
         connection.setServiceParent(self.service)
 
         # create a list of return values for connect. the last element is a deferred, which enables
-        # us to assert that the reconnecting haven't given up.
+        # us to assert that the reconnecting hasn't given up.
         endpoints = list()
         connect_return_values = [error.ConnectError('test_error'), error.DNSLookupError('test_error'), error.ConnectionDone('test_error'), Exception('test_exception'), defer.Deferred()]
         expected_errors = list(connect_return_values[:-1])

--- a/contrib/amqp/piped/contrib/amqp/test/test_rpc.py
+++ b/contrib/amqp/piped/contrib/amqp/test/test_rpc.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2010-2011, Found IT A/S and Piped Project Contributors.
+# See LICENSE for details.
+import mock
+from mock import patch
+from twisted.application import service
+from twisted.python import reflect
+from twisted.trial import unittest
+from twisted.internet import defer
+
+from piped import processing, dependencies
+from piped.contrib.amqp import rpc
+
+
+class StubRPCClient(rpc.RPCClientBase):
+    pass
+
+
+class TestConnectionProvider(unittest.TestCase):
+    def setUp(self):
+        self.runtime_environment = processing.RuntimeEnvironment()
+        self.runtime_environment.application = service.MultiService()
+        self.runtime_environment.configure()
+
+    def tearDown(self):
+        self.runtime_environment.application.stopService()
+
+    def test_provided_connections(self):
+        cm = self.runtime_environment.configuration_manager
+        cm.set('amqp.rpc_clients.test_client', dict(
+            connection = 'test_connection',
+            type = reflect.fullyQualifiedName(StubRPCClient),
+            consumer = dict(
+                queue = dict(
+                    queue = 'my_queue'
+                )
+            )
+        ))
+
+        provider = rpc.RPCClientProvider()
+        provider.configure(self.runtime_environment)
+
+        client_dependency = dependencies.ResourceDependency(provider='amqp.rpc_client.test_client')
+        self.runtime_environment.resource_manager.resolve(client_dependency)
+
+        mocked_connection = mock.Mock()
+        mocked_connection.channel.return_value.basic_consume.return_value = defer.DeferredQueue(), mock.Mock()
+
+        with patch.object(self.runtime_environment.resource_manager, 'resolve') as mocked_resolve:
+            def resolve(resource_dependency):
+                if 'amqp.connection' not in resource_dependency.provider:
+                    return self.runtime_environment.resource_manager.resolve(resource_dependency)
+
+                resource_dependency.on_resource_ready(mocked_connection)
+
+            # replace 'amqp.connection' with the mocked connection:
+            mocked_resolve.side_effect = resolve
+
+            self.runtime_environment.dependency_manager.resolve_initial_states()
+            provider.startService()
+
+        client = client_dependency.get_resource()
+        self.assertIsInstance(client, StubRPCClient)
+
+        self.assertEquals(client.consumer_config['queue']['queue'], 'my_queue')
+
+        # if another dependency asks for the same connection, it should receive the same instance
+        another_client_dependency = dependencies.ResourceDependency(provider='amqp.rpc_client.test_client')
+        self.runtime_environment.resource_manager.resolve(another_client_dependency)
+
+        self.assertIdentical(another_client_dependency.get_resource(), client_dependency.get_resource())
+
+
+class TestRPC(unittest.TestCase):
+
+    def setUp(self):
+        self.runtime_environment = processing.RuntimeEnvironment()
+        self.runtime_environment.application = service.MultiService()
+        self.runtime_environment.configure()
+
+    def tearDown(self):
+        return self.runtime_environment.application.stopService()
+
+    def _create_rpc_client(self, **rpc_config):
+        dm = self.runtime_environment.dependency_manager
+
+        rpc_config.setdefault('name', 'test_name')
+        rpc_config.setdefault('connection', 'test_connection')
+
+        rpc_client = rpc.RPCClientBase(**rpc_config)
+        rpc_client.configure(self.runtime_environment)
+
+        dm._dependency_graph.node[rpc_client.connection_dependency]['resolved'] = True
+        dm._dependency_graph.node[rpc_client.dependency]['resolved'] = True
+
+        return rpc_client
+
+
+    def test_connect_disconnect_when_service_starts_stops(self):
+        dm = self.runtime_environment.dependency_manager
+        rpc_client = self._create_rpc_client()
+
+        mocked_connection = mock.Mock()
+        mocked_channel = mocked_connection.channel.return_value = mock.Mock()
+
+        message_queue = defer.DeferredQueue()
+        mocked_consumer_tag = mock.Mock()
+        mocked_channel.basic_consume.return_value = message_queue, mocked_consumer_tag
+
+        rpc_client.connection_dependency.on_resource_ready(mocked_connection)
+
+        self.assertTrue(dm.has_all_dependencies_provided(rpc_client.dependency))
+        self.assertFalse(rpc_client.dependency.is_ready)
+
+        # starting the service should make the rpc-clients dependency ready
+        rpc_client.startService()
+        self.assertTrue(rpc_client.dependency.is_ready)
+        self.assertIsInstance(rpc_client._consuming, defer.Deferred)
+
+        with patch.object(rpc_client, 'process_response') as mocked_response:
+            message_queue.put((mocked_channel, mock.Mock(name='method'), mock.Mock(name='properties'), 'test message body'))
+
+            args = mocked_response.call_args[0]
+            self.assertEquals(args[0], mocked_channel)
+            self.assertEquals(args[1]._name, 'method')
+            self.assertEquals(args[2]._name, 'properties')
+            self.assertEquals(args[3], 'test message body')
+
+        # when the connection becomes lost, the rpc client should
+        # stop consuming
+        rpc_client.connection_dependency.on_resource_lost('test lost')
+        self.assertFalse(rpc_client.connection_dependency.is_ready)
+
+        #
+        self.assertNot(rpc_client._consuming)
+        self.assertFalse(rpc_client.dependency.is_ready)
+
+    def test_availability_on_connection_lost(self):
+        dm = self.runtime_environment.dependency_manager
+        rpc_client = self._create_rpc_client()
+
+        mocked_connection = mock.Mock()
+        mocked_channel = mocked_connection.channel.return_value = mock.Mock()
+
+        message_queue = defer.DeferredQueue()
+        mocked_consumer_tag = mock.Mock()
+        mocked_channel.basic_consume.return_value = message_queue, mocked_consumer_tag
+
+        rpc_client.connection_dependency.on_resource_ready(mocked_connection)
+
+        self.assertTrue(dm.has_all_dependencies_provided(rpc_client.dependency))
+        self.assertFalse(rpc_client.dependency.is_ready)
+
+        # starting the service should make the rpc-clients dependency ready
+        rpc_client.startService()
+        self.assertTrue(rpc_client.dependency.is_ready)
+        self.assertIsInstance(rpc_client._consuming, defer.Deferred)
+
+        # when the connection becomes lost, the rpc client should
+        # stop consuming
+        rpc_client.connection_dependency.on_resource_lost('test lost')
+        self.assertFalse(rpc_client.connection_dependency.is_ready)
+        self.assertFalse(rpc_client.dependency.is_ready)
+        self.assertNot(rpc_client._consuming)
+
+        rpc_client.connection_dependency.on_resource_ready(mocked_connection)
+        self.assertTrue(rpc_client.connection_dependency.is_ready)
+        self.assertTrue(rpc_client.dependency.is_ready)
+        self.assertIsInstance(rpc_client._consuming, defer.Deferred)
+
+        self.assertEquals(mocked_channel.basic_consume.call_count, 2)
+
+    def test_availability_on_start_stop_service(self):
+        dm = self.runtime_environment.dependency_manager
+        rpc_client = self._create_rpc_client()
+
+        mocked_connection = mock.Mock()
+        mocked_channel = mocked_connection.channel.return_value = mock.Mock()
+
+        message_queue = defer.DeferredQueue()
+        mocked_consumer_tag = mock.Mock()
+        mocked_channel.basic_consume.return_value = message_queue, mocked_consumer_tag
+
+        rpc_client.connection_dependency.on_resource_ready(mocked_connection)
+
+        self.assertTrue(dm.has_all_dependencies_provided(rpc_client.dependency))
+        self.assertFalse(rpc_client.dependency.is_ready)
+
+        # starting the service should make the rpc-clients dependency ready
+        rpc_client.startService()
+        self.assertTrue(rpc_client.dependency.is_ready)
+        self.assertIsInstance(rpc_client._consuming, defer.Deferred)
+
+        # when the service stops, the consumer client should stop consuming
+        rpc_client.stopService()
+        self.assertTrue(rpc_client.connection_dependency.is_ready)
+        self.assertFalse(rpc_client.dependency.is_ready)
+        self.assertNot(rpc_client._consuming)
+
+        rpc_client.startService()
+        self.assertTrue(rpc_client.connection_dependency.is_ready)
+        self.assertTrue(rpc_client.dependency.is_ready)
+        self.assertIsInstance(rpc_client._consuming, defer.Deferred)
+
+        self.assertEquals(mocked_channel.basic_consume.call_count, 2)
+
+    def test_consumer_configuration_no_ack(self):
+        rpc_client = self._create_rpc_client(consumer=dict(no_ack=False))
+
+        mocked_connection = mock.Mock()
+        mocked_channel = mocked_connection.channel.return_value = mock.Mock()
+        mocked_channel.queue_declare.return_value.method.queue = 'test-amqp-generated-queue-name'
+
+        message_queue = defer.DeferredQueue()
+        mocked_consumer_tag = mock.Mock()
+        mocked_channel.basic_consume.return_value = message_queue, mocked_consumer_tag
+
+        rpc_client.connection_dependency.on_resource_ready(mocked_connection)
+        rpc_client.startService()
+
+        # the consumer should use the generated queue name when starting to consume
+        mocked_channel.basic_consume.assert_called_once_with(
+            queue = 'test-amqp-generated-queue-name',
+            no_ack = False,
+            exclusive = True
+        )
+
+    def test_consumer_configuration_custom_queue_name(self):
+        rpc_client = self._create_rpc_client(consumer=dict(queue='my_queue'))
+
+        mocked_connection = mock.Mock()
+        mocked_channel = mocked_connection.channel.return_value = mock.Mock()
+
+        def queue_declare(queue, **rest):
+            m = mock.Mock()
+            m.method.queue = queue
+            return m
+
+        mocked_channel.queue_declare.side_effect = queue_declare
+
+        message_queue = defer.DeferredQueue()
+        mocked_consumer_tag = mock.Mock()
+        mocked_channel.basic_consume.return_value = message_queue, mocked_consumer_tag
+
+        rpc_client.connection_dependency.on_resource_ready(mocked_connection)
+        rpc_client.startService()
+
+        # the consumer should use the configured queue name when starting to consume
+        mocked_channel.basic_consume.assert_called_once_with(
+            queue = 'my_queue',
+            no_ack = True,
+            exclusive = True
+        )

--- a/contrib/amqp/setup.py
+++ b/contrib/amqp/setup.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2010-2011, Found IT A/S and Piped Project Contributors.
+# See LICENSE for details.
+import os
+import sys
+
+from setuptools import setup, find_packages
+
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+# add ourselves to the package path so we can get the version from the source tree
+sys.path.insert(0, here)
+import piped.contrib.amqp
+
+setup(
+    name = 'piped.contrib.amqp',
+    license = 'MIT',
+
+    author = 'Piped Project Contributors',
+    author_email = 'piped@librelist.com',
+    url = 'http://piped.io',
+
+    packages = find_packages(where=here),
+    namespace_packages = ['piped', 'piped.contrib'],
+
+    version = str(piped.contrib.amqp.version),
+    classifiers = [
+        'Development Status :: 4 - Beta',
+        'Environment :: Plugins',
+        'Framework :: Twisted',
+        'Operating System :: OS Independent',
+    ],
+    description = 'AMQP support for Piped.',
+
+    install_requires = ['piped', 'pika', 'setuptools']
+)

--- a/doc/reference/providers.rst
+++ b/doc/reference/providers.rst
@@ -183,6 +183,48 @@ More detailed tracebacks with live objects are available if :option:`piped -D` i
 Contrib providers
 -----------------
 
+
+amqp
+^^^^
+
+Connecting
+""""""""""
+
+.. currentmodule:: piped.contrib.amqp.providers
+
+.. autoclass:: AMQPConnectionProvider
+    :members:
+
+.. autoclass:: AMQPConnection
+    :members:
+
+.. autoclass:: AMQProtocol
+    :members:
+
+
+Consuming
+"""""""""
+
+.. currentmodule:: piped.contrib.amqp.providers
+
+.. autoclass:: AMQPConsumerProvider
+    :members:
+
+.. autoclass:: AMQPConsumer
+    :members:
+
+RPC helpers
+"""""""""""
+
+.. currentmodule:: piped.contrib.amqp.rpc
+
+.. autoclass:: RPCClientProvider
+    :members:
+
+.. autoclass:: RPCClientBase
+    :members:
+
+
 database
 ^^^^^^^^
 

--- a/piped/log.py
+++ b/piped/log.py
@@ -195,7 +195,7 @@ def _set_global_logger(logger):
 
 # default to using an non-configured DefaultLogger until something else is configured.
 # the reason this is defined in-line instead of using _set_global_logger is to assist
-# IDEs in recognizig the logging functions
+# IDEs in recognizing the logging functions
 
 _logger = DefaultLogger()
 debug = _logger.debug

--- a/piped/util.py
+++ b/piped/util.py
@@ -584,7 +584,7 @@ def create_deferred_state_watcher(obj, attribute_name='_currently'):
     the attribute is cleared.
 
     This can be used to implement functions that should only be executed by one concurrent
-    thread:
+    invocation:
 
         >>> class A(object):
         ...     running = None # stores the currently running state

--- a/piped/util.py
+++ b/piped/util.py
@@ -575,3 +575,46 @@ class NonCleaningFailure(failure.Failure):
 
     def cleanFailure(self):
         pass
+
+
+def create_deferred_state_watcher(obj, attribute_name='_currently'):
+    """
+    Creates a function that when called with a deferred, assigns the deferred to the
+    specified attribute on the target object. When the deferred callbacks or errbacks,
+    the attribute is cleared.
+
+    This can be used to implement functions that should only be executed by one concurrent
+    thread:
+
+        >>> class A(object):
+        ...     running = None # stores the currently running state
+        ...
+        ...     def run(self):
+        ...         if self.running:
+        ...             # in this example we return here, but we could have called
+        ...             # ``self.running.cancel()`` to cancel the previous invocation and continued.
+        ...             print 'already running'
+        ...             return
+        ...
+        ...         # create the watcher.
+        ...         currently = create_deferred_state_watcher(self, 'running')
+        ...
+        ...         return currently(wait(0))
+        ...
+        >>> a = A()
+        >>> d = a.run()
+        >>> a.run()
+        already running
+    """
+    def clear(result):
+        setattr(obj, attribute_name, None)
+        return result
+
+    def wrapper(retval):
+        if isinstance(retval, defer.Deferred):
+            setattr(obj, attribute_name, retval)
+            retval.addBoth(clear)
+
+        return retval
+
+    return wrapper


### PR DESCRIPTION
Initial AMQP support for Piped.

This implementation provides connections and basic consumers.

Also included are additional support for writing RPC-style clients, with a RPCClientProvider and a base class that enables easy consuming of RPC responses.
