### PR TITLE
General processors

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -37,7 +37,7 @@ Backward-incompatible changes:
 
             OR
 
-            - procsesor_name:
+            - processor_name:
                 foo: bar
 
             OR

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,12 +9,43 @@ Features:
       and processing them in pipelines, as well as a simple helper
       for creating and providing AMQP-based RPC-clients.
 
+    - Built-in and contrib providers now use "processor: ..." instead
+        of "pipeline: ...", and are able to depend on arbitrary dependencies.
+        The dependencies are invoked with the baton as the first and
+        only argument.
+
+        This makes it easier for one provider to call a function on another
+        provider.
+
 New processors:
     - get-zookeeper-children: Get a list of children for a ZooKeeper node.
     - get-zookeeper-data: Get the data of a ZooKeeper node.
     - zookeeper-node-exists: Check whether a given ZooKeeper node exists.
     - set-zookeeper-data: Set the contents of a ZooKeeper node.
     - create-zookeeper-node: Create a ZooKeeper node.
+
+Internal changes:
+    - piped.processing now uses stores the processor name under the
+        '__processor__' key instead of 'processor', enabling processors to
+        take 'processor' as a keyword argument.
+
+Backward-incompatible changes:
+    - The syntax for creating processors in the YAML configuration has changed.
+        Using "processor: processor_name" is no longer supported. Use
+
+            - processor_name
+
+            OR
+
+            - procsesor_name:
+                foo: bar
+
+            OR
+
+            - __processor__: processor_name
+              foo: bar
+
+         instead.
 
 ========================== Release 0.2.0 2011-10-17 ==========================
 

--- a/contrib/status_testing/piped/contrib/status_testing/processors.py
+++ b/contrib/status_testing/piped/contrib/status_testing/processors.py
@@ -20,13 +20,13 @@ class ReporterCreator(base.Processor):
     interface.classProvides(processing.IProcessor)
     name = 'create-statustest-reporter'
 
-    def __init__(self, reporter='piped.contrib.status_testing.statustest.ProcessorReporter', result_processor=None, arguments=None, output_path='reporter', **kw):
+    def __init__(self, reporter='piped.contrib.status_testing.statustest.ProcessorReporter', processor=None, arguments=None, output_path='reporter', **kw):
         """
 
         :param reporter: The fully qualified name of the reporter class to instantiate. This
             should be a subclass of :class:`~piped.contrib.status_testing.statustest.PipelineReporter`.
 
-        :param result_processor: The name of a processor that will be used. The resulting dependency
+        :param processor: The name of a processor that will be used. The resulting dependency
             object is passed to the reporter as the first argument. If set to ``None`` the dependency
             will also be ``None``, and no processor will be used.
 
@@ -39,7 +39,7 @@ class ReporterCreator(base.Processor):
         """
         super(ReporterCreator, self).__init__(**kw)
 
-        self.processor_config = dict(provider=result_processor) if isinstance(result_processor, basestring) else result_processor
+        self.processor_config = dict(provider=processor) if isinstance(processor, basestring) else processor
         self.reporter_name = reporter
 
         self.output_path = output_path

--- a/contrib/status_testing/piped/contrib/status_testing/statustest.py
+++ b/contrib/status_testing/piped/contrib/status_testing/statustest.py
@@ -99,12 +99,12 @@ class StatusReporter(reporter.TreeReporter):
         super(StatusReporter, self).__init__(stream=StreamAdapter(stream), **kw)
 
 
-class PipelineReporter(StatusReporter):
-    """ Reporter that can pass test results into a pipeline. """
+class ProcessorReporter(StatusReporter):
+    """ Reporter that can pass test results using a processor. """
 
-    def __init__(self, pipeline_dependency=None, *a, **kw):
-        super(PipelineReporter, self).__init__(*a, **kw)
-        self.pipeline_dependency = pipeline_dependency
+    def __init__(self, processor_dependency=None, *a, **kw):
+        super(ProcessorReporter, self).__init__(*a, **kw)
+        self.processor_dependency = processor_dependency
         self._in_processing = []
 
     def wait_for_result_processing(self):
@@ -113,41 +113,41 @@ class PipelineReporter(StatusReporter):
 
     @defer.inlineCallbacks
     def process_baton(self, baton):
-        if not self.pipeline_dependency:
+        if not self.processor_dependency:
             return
         
-        pipeline = yield self.pipeline_dependency.wait_for_resource()
+        processor = yield self.processor_dependency.wait_for_resource()
 
         baton['reporter'] = self
-        yield pipeline.process(baton)
+        yield processor(baton)
 
     def addSuccess(self, test):
-        super(PipelineReporter, self).addSuccess(test)
+        super(ProcessorReporter, self).addSuccess(test)
         d = self.process_baton(dict(test=test, status='success'))
         self._in_processing.append(d)
 
     def addFailure(self, test, err):
-        super(PipelineReporter, self).addFailure(test, err)
+        super(ProcessorReporter, self).addFailure(test, err)
         d = self.process_baton(dict(test=test, failure=err, status='failure'))
         self._in_processing.append(d)
 
     def addError(self, test, err):
-        super(PipelineReporter, self).addError(test, err)
+        super(ProcessorReporter, self).addError(test, err)
         d = self.process_baton(dict(test=test, failure=err, status='error'))
         self._in_processing.append(d)
 
     def addSkip(self, test, err):
-        super(PipelineReporter, self).addSkip(test, err)
+        super(ProcessorReporter, self).addSkip(test, err)
         d = self.process_baton(dict(test=test, failure=err, status='skipped'))
         self._in_processing.append(d)
 
     def addExpectedFailure(self, test, err, todo):
-        super(PipelineReporter, self).addExpectedFailure(test, err, todo)
+        super(ProcessorReporter, self).addExpectedFailure(test, err, todo)
         d = self.process_baton(dict(test=test, failure=err, status='expected_failure'))
         self._in_processing.append(d)
 
     def addUnexpectedSuccess(self, test, todo):
-        super(PipelineReporter, self).addUnexpectedSuccess(test, todo)
+        super(ProcessorReporter, self).addUnexpectedSuccess(test, todo)
         d = self.process_baton(dict(test=test, todo=todo, status='todone'))
         self._in_processing.append(d)
 

--- a/contrib/status_testing/piped/contrib/status_testing/test/test_processors.py
+++ b/contrib/status_testing/piped/contrib/status_testing/test/test_processors.py
@@ -61,7 +61,7 @@ class TestSimpleStatus(unittest.TestCase):
             collect=['collect-batons'],
             status=[
                     dict(processor='call-named-any', name='StringIO.StringIO', output_path='stream'),
-                    dict(processor='create-statustest-reporter', arguments=dict(stream_path='stream'), pipeline='collect'),
+                    dict(processor='create-statustest-reporter', arguments=dict(stream_path='stream'), result_processor='pipeline.collect'),
                     'test-processor',
                     'test-processor-success',
                     'wait-for-statustest-reporter'
@@ -83,8 +83,8 @@ class TestSimpleStatus(unittest.TestCase):
 
         # get the report creator processor
         report_creator = list(evaluators['status'])[1]
-        report_creator.pipeline_dependency.on_resource_ready(evaluators['collect'])
-        report_creator.pipeline_dependency.fire_on_ready()
+        report_creator.processor_dependency.on_resource_ready(evaluators['collect'].process)
+        report_creator.processor_dependency.fire_on_ready()
 
         processed = yield evaluators['status'].process(dict())
 
@@ -103,7 +103,7 @@ class TestSimpleStatus(unittest.TestCase):
         self.assertEquals(len(reporter.unexpectedSuccesses), 1)
 
     @defer.inlineCallbacks
-    def test_without_reporter_pipeline(self):
+    def test_without_reporter_processor(self):
         self.runtime_environment.configuration_manager.set('pipelines', dict(
             status=[
                     dict(processor='call-named-any', name='StringIO.StringIO', output_path='stream'),

--- a/contrib/status_testing/piped/contrib/status_testing/test/test_processors.py
+++ b/contrib/status_testing/piped/contrib/status_testing/test/test_processors.py
@@ -60,8 +60,8 @@ class TestSimpleStatus(unittest.TestCase):
         self.runtime_environment.configuration_manager.set('pipelines', dict(
             collect=['collect-batons'],
             status=[
-                    dict(processor='call-named-any', name='StringIO.StringIO', output_path='stream'),
-                    dict(processor='create-statustest-reporter', arguments=dict(stream_path='stream'), result_processor='pipeline.collect'),
+                    {'call-named-any': dict(name='StringIO.StringIO', output_path='stream')},
+                    {'create-statustest-reporter': dict(arguments=dict(stream_path='stream'), processor='pipeline.collect')},
                     'test-processor',
                     'test-processor-success',
                     'wait-for-statustest-reporter'
@@ -106,11 +106,11 @@ class TestSimpleStatus(unittest.TestCase):
     def test_without_reporter_processor(self):
         self.runtime_environment.configuration_manager.set('pipelines', dict(
             status=[
-                    dict(processor='call-named-any', name='StringIO.StringIO', output_path='stream'),
-                    dict(processor='create-statustest-reporter', arguments=dict(stream_path='stream')),
+                    {'call-named-any': dict(name='StringIO.StringIO', output_path='stream')},
+                    {'create-statustest-reporter': dict(arguments=dict(stream_path='stream'))},
                     'test-processor',
                     'test-processor-success',
-                    dict(processor='wait-for-statustest-reporter', done=True)
+                    {'wait-for-statustest-reporter': dict(done=True)}
             ]
         ))
 

--- a/contrib/zookeeper/piped/contrib/zookeeper/test/test_providers.py
+++ b/contrib/zookeeper/piped/contrib/zookeeper/test/test_providers.py
@@ -54,7 +54,7 @@ class TestClientProvider(unittest.TestCase):
             dict(
                 servers = 'localhost:2181/foo,localhost:2182/bar',
                 events = dict(
-                    starting = 'pipeline_name'
+                    starting = 'processor_name'
                 )
             )
         )
@@ -79,7 +79,7 @@ class TestClient(unittest.TestCase):
 
         self.assertRaises(exceptions.ConfigurationError, client.configure, self.runtime_environment)
 
-    def test_pipelines_depended_on(self):
+    def test_processors_depended_on(self):
         events = dict(
             zip(providers.PipedZookeeperClient.possible_events, providers.PipedZookeeperClient.possible_events)
         )
@@ -96,12 +96,10 @@ class TestClient(unittest.TestCase):
         for dependency in dependencies:
             dependency_by_provider_name[dependency.provider] = dependency
 
-        # all the events should have a pipeline
+        # all the events should have a processor
         for event in events.keys():
-            pipeline_name = 'pipeline.{0}'.format(event)
-            self.assertIn(pipeline_name, dependency_by_provider_name)
-
-            dependency_by_provider_name.pop(pipeline_name)
+            self.assertIn(event, dependency_by_provider_name)
+            dependency_by_provider_name.pop(event)
 
         self.assertEquals(dependency_by_provider_name, dict())
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -55,7 +55,7 @@ If you just want to have a peek at how ``hello world`` looks in Piped, here is a
         first_step:
             routing:
                 __config__:
-                    pipeline: hello
+                    processor: pipeline.hello
 
     pipelines:
         hello:

--- a/doc/reference/processing.rst
+++ b/doc/reference/processing.rst
@@ -5,7 +5,7 @@ Processing
 .. module:: piped.processing
 
 
-The ``piped.processing`` module is contains some core classes that are used in the
+The ``piped.processing`` module contains core classes that are used in the
 pipeline processing.
 
 

--- a/doc/reference/providers.rst
+++ b/doc/reference/providers.rst
@@ -67,7 +67,7 @@ The following is an processor stub that processes a baton in a pipeline for ever
         baton_to_process = dict(foo='bar')
 
         # wait until the pipeline has finished processing the baton_to_process:
-        yield pipeline.process(baton_to_process)
+        yield pipeline(baton_to_process)
 
         # return the baton unchanged
         defer.returnValue(baton)
@@ -243,7 +243,7 @@ zmq
 ^^^
 
 .. automodule:: piped.contrib.zmq.providers
-    :members: ZMQSocketProvider, ZMQPipelineFeederProvider
+    :members: ZMQSocketProvider, ZMQProcessorFeederProvider
 
 
 zookeeper

--- a/doc/topic/pipelines.rst
+++ b/doc/topic/pipelines.rst
@@ -306,19 +306,8 @@ A :class:`dict` with a single key, the processor name, may be used to pass optio
             foo: bar
 
 
-Using a dict containing the key ``processor``
-"""""""""""""""""""""""""""""""""""""""""""""
-
-A dictionary with the ``processor`` key set to the processor name::
-
-    my_pipeline:
-        - processor: processor_name
-          foo: bar
-
-
-
-Special keys used in processor definitions
-""""""""""""""""""""""""""""""""""""""""""
+Reserved keys used in processor definitions
+"""""""""""""""""""""""""""""""""""""""""""
 
 id:
     Used to give processors an unique id within a processor graph.
@@ -334,7 +323,8 @@ error_consumers:
     Same as consumers, but used when the processor or one of its consumers
     raises an exception.
 
-
+__processor__:
+    Reserved for internal rewriting of processor graphs.
 
 
 .. note:: Depending on how the processor is used within a processor graph, the

--- a/doc/topic/pipelines.rst
+++ b/doc/topic/pipelines.rst
@@ -306,6 +306,17 @@ A :class:`dict` with a single key, the processor name, may be used to pass optio
             foo: bar
 
 
+Using a dict containing the key ``__processor__``
+"""""""""""""""""""""""""""""""""""""""""""""""""
+
+A dictionary with the ``__processor__`` key set to the processor name::
+
+    my_pipeline:
+        - __processor__: processor_name
+          foo: bar
+
+
+
 Reserved keys used in processor definitions
 """""""""""""""""""""""""""""""""""""""""""
 

--- a/doc/topic/resources.rst
+++ b/doc/topic/resources.rst
@@ -51,7 +51,7 @@ Here is an example processor that depends on a pipeline as a resource:
             pipeline = yield self.pipeline_resource.wait_for_resource()
 
             # process the baton in the pipeline, and wait until the processing is done
-            yield pipeline.process(baton)
+            yield pipeline(baton)
 
             defer.returnValue(baton)
 

--- a/doc/topic/testing.rst
+++ b/doc/topic/testing.rst
@@ -57,7 +57,7 @@ The following configuration runs a list of test processors inside the same proce
 
     system-events:
         startup:
-            test: system-testing.start
+            test: pipeline.system-testing.start
 
     pipelines:
         system-testing:    
@@ -102,7 +102,7 @@ Status tests can also be run continuous:
             system_testing.start:
                 # run the tests every 5 seconds:
                 interval: 5
-                pipeline: system-testing.start
+                processor: pipeline.system-testing.start
 
     pipelines:
         system-testing:
@@ -135,7 +135,8 @@ The above tests will output their results to the logging mechanism, but creating
         system-testing:
             port: 8080
             routing:
-                __pipeline__: web.system-testing
+                __config__:
+                    processor: pipeline.web.system-testing
 
     pipelines:
         web:

--- a/doc/tutorials/distributing/1/rpc-server.yaml
+++ b/doc/tutorials/distributing/1/rpc-server.yaml
@@ -2,7 +2,7 @@ web:
     site:
         routing:
             __config__:
-                pipeline: web.compute
+                processor: pipeline.web.compute
 
 pipelines:
     web:

--- a/doc/tutorials/distributing/1/test-rpc.yaml
+++ b/doc/tutorials/distributing/1/test-rpc.yaml
@@ -12,7 +12,7 @@ web:
 
 system-events:
     startup:
-        system-test: system-testing.start
+        system-test: pipeline.system-testing.start
 
 pipelines:
     system-testing:

--- a/doc/tutorials/distributing/2/rpc-client-square.yaml
+++ b/doc/tutorials/distributing/2/rpc-client-square.yaml
@@ -4,7 +4,7 @@ includes:
 zmq:
     queues:
         worker_square_in:
-            pipeline: zmq.square
+            processor: pipeline.zmq.square
     
 pipelines:
     zmq:

--- a/doc/tutorials/distributing/2/rpc-client-sum.yaml
+++ b/doc/tutorials/distributing/2/rpc-client-sum.yaml
@@ -4,7 +4,7 @@ includes:
 zmq:
     queues:
         worker_sum_in:
-            pipeline: zmq.sum
+            processor: pipeline.zmq.sum
     
 pipelines:
     zmq:

--- a/doc/tutorials/distributing/2/rpc-server.yaml
+++ b/doc/tutorials/distributing/2/rpc-server.yaml
@@ -2,7 +2,7 @@ web:
     site:
         routing:
             __config__:
-                pipeline: web.compute
+                processor: pipeline.web.compute
 
 pipelines:
     web:

--- a/doc/tutorials/distributing/2/rpc_tutorial/test_client.py
+++ b/doc/tutorials/distributing/2/rpc_tutorial/test_client.py
@@ -20,14 +20,14 @@ class TestClientProcessor(processors.StatusTestProcessor):
         @defer.inlineCallbacks
         def statustest_simple_sum(self):
             input = json.dumps(dict(numbers=[1,2,3]))
-            results = yield self.sum_pipeline.process(input)
+            results = yield self.sum_pipeline(input)
             output = json.loads(results[0])
             self.assertEquals(output['sum'], 14)
 
         @defer.inlineCallbacks
         def statustest_simple_square(self):
             input = json.dumps(dict(numbers=[1,2,3]))
-            results = yield self.square_pipeline.process(input)
+            results = yield self.square_pipeline(input)
             output = json.loads(results[0])
             self.assertEquals(output['square'], 36)
 

--- a/doc/tutorials/distributing/2/test-rpc.yaml
+++ b/doc/tutorials/distributing/2/test-rpc.yaml
@@ -13,7 +13,7 @@ web:
 
 system-events:
     startup:
-        system-test: system-testing.start
+        system-test: pipeline.system-testing.start
 
 pipelines:
     system-testing:

--- a/doc/tutorials/distributing/3/rpc-client-square.yaml
+++ b/doc/tutorials/distributing/3/rpc-client-square.yaml
@@ -4,7 +4,7 @@ includes:
 zmq:
     queues:
         worker_square_in:
-            pipeline: zmq.square
+            processor: pipeline.zmq.square
     
 pipelines:
     zmq:

--- a/doc/tutorials/distributing/3/rpc-client-sum.yaml
+++ b/doc/tutorials/distributing/3/rpc-client-sum.yaml
@@ -4,7 +4,7 @@ includes:
 zmq:
     queues:
         worker_sum_in:
-            pipeline: zmq.sum
+            processor: pipeline.zmq.sum
     
 pipelines:
     zmq:

--- a/doc/tutorials/distributing/3/rpc-server.yaml
+++ b/doc/tutorials/distributing/3/rpc-server.yaml
@@ -4,9 +4,9 @@ includes:
 zmq:
     queues:
         server_sum_in:
-            pipeline: zmq.partial_response
+            processor: pipeline.zmq.partial_response
         server_square_in:
-            pipeline: zmq.partial_response
+            processor: pipeline.zmq.partial_response
 web:
     site:
         port: 8080
@@ -15,7 +15,7 @@ web:
                 - localhost
         routing:
             __config__:
-                pipeline: web.compute
+                processor: pipeline.web.compute
 
 # We use a shared context (that starts out as an empty dictionary) to
 # store requests that haven't been completed yet.

--- a/doc/tutorials/distributing/3/rpc_tutorial/test_client.py
+++ b/doc/tutorials/distributing/3/rpc_tutorial/test_client.py
@@ -20,14 +20,14 @@ class TestClientProcessor(processors.StatusTestProcessor):
         @defer.inlineCallbacks
         def statustest_simple_sum(self):
             input = json.dumps(dict(numbers=[1,2,3]))
-            results = yield self.sum_pipeline.process(input)
+            results = yield self.sum_pipeline(input)
             output = json.loads(results[0])
             self.assertEquals(output['sum'], 14)
 
         @defer.inlineCallbacks
         def statustest_simple_square(self):
             input = json.dumps(dict(numbers=[1,2,3]))
-            results = yield self.square_pipeline.process(input)
+            results = yield self.square_pipeline(input)
             output = json.loads(results[0])
             self.assertEquals(output['square'], 36)
 

--- a/doc/tutorials/distributing/3/test-rpc.yaml
+++ b/doc/tutorials/distributing/3/test-rpc.yaml
@@ -9,7 +9,7 @@ plugins:
 
 system-events:
     startup:
-        system-test: system-testing.start
+        system-test: pipeline.system-testing.start
 
 pipelines:
     system-testing:

--- a/doc/tutorials/distributing/3/util.yaml
+++ b/doc/tutorials/distributing/3/util.yaml
@@ -3,10 +3,10 @@ web:
         routing:
             dependencies:
                 __config__:
-                    pipeline: web.dependencies
+                    processor: pipeline.web.dependencies
             pipelines:
                 __config__:
-                    pipeline: web.pipelines
+                    processor: pipeline.web.pipelines
             
     
 pipelines:

--- a/doc/tutorials/distributing/4/rpc-client-square.yaml
+++ b/doc/tutorials/distributing/4/rpc-client-square.yaml
@@ -4,7 +4,7 @@ includes:
 zmq:
     queues:
         worker_square_in:
-            pipeline: zmq.square
+            processor: pipeline.zmq.square
     
 pipelines:
     zmq:

--- a/doc/tutorials/distributing/4/rpc-client-sum.yaml
+++ b/doc/tutorials/distributing/4/rpc-client-sum.yaml
@@ -4,7 +4,7 @@ includes:
 zmq:
     queues:
         worker_sum_in:
-            pipeline: zmq.sum
+            processor: pipeline.zmq.sum
     
 pipelines:
     zmq:

--- a/doc/tutorials/distributing/4/rpc-server-reaper.yaml
+++ b/doc/tutorials/distributing/4/rpc-server-reaper.yaml
@@ -3,7 +3,7 @@ ticks:
         reaper:
             # create a baton every second and process it in the reap-pending-batons pipeline:
             interval: 1
-            pipeline: reap-pending-batons
+            processor: pipeline.reap-pending-batons
 
 pipelines:
     reap-pending-batons:

--- a/doc/tutorials/distributing/4/rpc-server.yaml
+++ b/doc/tutorials/distributing/4/rpc-server.yaml
@@ -5,9 +5,9 @@ includes:
 zmq:
     queues:
         server_sum_in:
-            pipeline: zmq.partial_response
+            processor: pipeline.zmq.partial_response
         server_square_in:
-            pipeline: zmq.partial_response
+            processor: pipeline.zmq.partial_response
 web:
     site:
         port: 8080
@@ -16,7 +16,7 @@ web:
                 - localhost
         routing:
             __config__:
-                pipeline: web.compute
+                processor: pipeline.web.compute
 
 # We use a shared context (that starts out as an empty dictionary) to
 # store requests that haven't been completed yet.

--- a/doc/tutorials/distributing/4/rpc_tutorial/test_client.py
+++ b/doc/tutorials/distributing/4/rpc_tutorial/test_client.py
@@ -20,14 +20,14 @@ class TestClientProcessor(processors.StatusTestProcessor):
         @defer.inlineCallbacks
         def statustest_simple_sum(self):
             input = json.dumps(dict(numbers=[1,2,3]))
-            results = yield self.sum_pipeline.process(input)
+            results = yield self.sum_pipeline(input)
             output = json.loads(results[0])
             self.assertEquals(output['sum'], 14)
 
         @defer.inlineCallbacks
         def statustest_simple_square(self):
             input = json.dumps(dict(numbers=[1,2,3]))
-            results = yield self.square_pipeline.process(input)
+            results = yield self.square_pipeline(input)
             output = json.loads(results[0])
             self.assertEquals(output['square'], 36)
 

--- a/doc/tutorials/distributing/4/test-rpc.yaml
+++ b/doc/tutorials/distributing/4/test-rpc.yaml
@@ -9,7 +9,7 @@ plugins:
 
 system-events:
     startup:
-        system-test: system-testing.start
+        system-test: pipeline.system-testing.start
 
 pipelines:
     system-testing:

--- a/doc/tutorials/distributing/4/util.yaml
+++ b/doc/tutorials/distributing/4/util.yaml
@@ -3,10 +3,10 @@ web:
         routing:
             dependencies:
                 __config__:
-                    pipeline: web.dependencies
+                    processor: pipeline.web.dependencies
             pipelines:
                 __config__:
-                    pipeline: web.pipelines
+                    processor: pipeline.web.pipelines
             
     
 pipelines:

--- a/doc/tutorials/getting_started/2_pipeline/tutorial.yaml
+++ b/doc/tutorials/getting_started/2_pipeline/tutorial.yaml
@@ -4,7 +4,7 @@ web:
         routing:
             __config__:
                 # use the hello pipeline to render the requests to this resource
-                pipeline: hello
+                processor: pipeline.hello
 
 pipelines:
     hello:

--- a/doc/tutorials/getting_started/3_processor/tutorial.yaml
+++ b/doc/tutorials/getting_started/3_processor/tutorial.yaml
@@ -4,7 +4,7 @@ web:
         routing:
             __config__:
                 # use the hello pipeline to render the requests to this resource
-                pipeline: hello
+                processor: pipeline.hello
 
 plugins:
     bundles:

--- a/doc/tutorials/getting_started/4_communicating/pb-server-with-callback.yaml
+++ b/doc/tutorials/getting_started/4_communicating/pb-server-with-callback.yaml
@@ -6,7 +6,7 @@ pb:
             # tell it to listen for incoming tcp connections on port 8789
             listen: tcp:8789
             # all messages should be handled by the pb-server pipeline
-            pipeline: pb-server
+            processor: pipeline.pb-server
 
 pipelines:
     pb-server:

--- a/doc/tutorials/getting_started/4_communicating/pb-server.yaml
+++ b/doc/tutorials/getting_started/4_communicating/pb-server.yaml
@@ -6,7 +6,7 @@ pb:
             # tell it to listen for incoming tcp connections on port 8789
             listen: tcp:8789
             # all messages should be handled by the pb-server pipeline
-            pipeline: pb-server
+            processor: pipeline.pb-server
 
 
 pipelines:

--- a/doc/tutorials/getting_started/4_communicating/tutorial.yaml
+++ b/doc/tutorials/getting_started/4_communicating/tutorial.yaml
@@ -2,7 +2,7 @@ web:
     tutorial:
         routing:
             __config__:
-                pipeline: hello
+                processor: pipeline.hello
 
 plugins:
     bundles:

--- a/doc/tutorials/getting_started/4_communicating/tutorial_allow.yaml
+++ b/doc/tutorials/getting_started/4_communicating/tutorial_allow.yaml
@@ -5,7 +5,7 @@ web:
                 - localhost
         routing:
             __config__:
-                pipeline: hello
+                processor: pipeline.hello
 
 plugins:
     bundles:

--- a/doc/tutorials/getting_started/5_visualizing/pb-server.yaml
+++ b/doc/tutorials/getting_started/5_visualizing/pb-server.yaml
@@ -6,7 +6,7 @@ pb:
             # tell it to listen for incoming tcp connections on port 8789
             listen: tcp:8789
             # all messages should be handled by the pb-server pipeline
-            pipeline: pb-server
+            processor: pipeline.pb-server
 
 
 pipelines:

--- a/doc/tutorials/getting_started/5_visualizing/tutorial.yaml
+++ b/doc/tutorials/getting_started/5_visualizing/tutorial.yaml
@@ -9,7 +9,7 @@ web:
                 - localhost
         routing:
             __config__:
-                pipeline: hello
+                processor: pipeline.hello
 
 plugins:
     bundles:

--- a/doc/tutorials/getting_started/5_visualizing/visualize-dependencies.yaml
+++ b/doc/tutorials/getting_started/5_visualizing/visualize-dependencies.yaml
@@ -3,7 +3,7 @@ web:
         routing:
             dependencies:
                 __config__:
-                    pipeline: web.dependencies
+                    processor: pipeline.web.dependencies
 
 pipelines:
     web:

--- a/doc/tutorials/getting_started/5_visualizing/visualize-pipelines.yaml
+++ b/doc/tutorials/getting_started/5_visualizing/visualize-pipelines.yaml
@@ -3,7 +3,7 @@ web:
         routing:
             pipelines:
                 __config__:
-                    pipeline: web.pipelines
+                    processor: pipeline.web.pipelines
 
 pipelines:
     web:

--- a/doc/tutorials/getting_started/6_testing/pb-server.yaml
+++ b/doc/tutorials/getting_started/6_testing/pb-server.yaml
@@ -6,7 +6,7 @@ pb:
             # tell it to listen for incoming tcp connections on port 8789
             listen: tcp:8789
             # all messages should be handled by the pb-server pipeline
-            pipeline: pb-server
+            processor: pipeline.pb-server
 
 
 pipelines:

--- a/doc/tutorials/getting_started/6_testing/test-tutorial.yaml
+++ b/doc/tutorials/getting_started/6_testing/test-tutorial.yaml
@@ -8,7 +8,7 @@ includes:
 # system-testing.start pipeline once when the process starts
 system-events:
     startup:
-        test: system-testing.start
+        test: pipeline.system-testing.start
 
 pipelines:
     system-testing:

--- a/doc/tutorials/getting_started/6_testing/tutorial.yaml
+++ b/doc/tutorials/getting_started/6_testing/tutorial.yaml
@@ -9,7 +9,7 @@ web:
                 - localhost
         routing:
             __config__:
-                pipeline: hello
+                processor: pipeline.hello
 
 plugins:
     bundles:

--- a/doc/tutorials/getting_started/6_testing/visualize-dependencies.yaml
+++ b/doc/tutorials/getting_started/6_testing/visualize-dependencies.yaml
@@ -3,7 +3,7 @@ web:
         routing:
             dependencies:
                 __config__:
-                    pipeline: web.dependencies
+                    processor: pipeline.web.dependencies
 
 pipelines:
     web:

--- a/doc/tutorials/getting_started/6_testing/visualize-pipelines.yaml
+++ b/doc/tutorials/getting_started/6_testing/visualize-pipelines.yaml
@@ -3,7 +3,7 @@ web:
         routing:
             pipelines:
                 __config__:
-                    pipeline: web.pipelines
+                    processor: pipeline.web.pipelines
 
 pipelines:
     web:

--- a/doc/tutorials/tracing/tracing.yaml
+++ b/doc/tutorials/tracing/tracing.yaml
@@ -7,7 +7,7 @@ web:
             allow: [localhost]
         routing:
             __config__:
-                pipeline: tracing
+                processor: pipeline.tracing
 
 pipelines:
     tracing:

--- a/doc/tutorials/twitter/1_basic/test_twitter.yaml
+++ b/doc/tutorials/twitter/1_basic/test_twitter.yaml
@@ -10,7 +10,7 @@ plugins:
 
 system-events:
     startup:
-        test: system-testing
+        test: pipeline.system-testing
 
 pipelines:
     system-testing:

--- a/doc/tutorials/twitter/1_basic/twitter.yaml
+++ b/doc/tutorials/twitter/1_basic/twitter.yaml
@@ -15,7 +15,7 @@ twitter:
 # use the startup event to run the "startup" pipeline once
 system-events:
     startup:
-        tutorial: startup
+        tutorial: pipeline.startup
 
 pipelines:
     startup:

--- a/doc/tutorials/twitter/2_oauth/test_twitter.yaml
+++ b/doc/tutorials/twitter/2_oauth/test_twitter.yaml
@@ -10,7 +10,7 @@ plugins:
 
 system-events:
     startup:
-        test: system-testing
+        test: pipeline.system-testing
 
 pipelines:
     system-testing:

--- a/doc/tutorials/twitter/2_oauth/twitter.yaml
+++ b/doc/tutorials/twitter/2_oauth/twitter.yaml
@@ -19,7 +19,7 @@ twitter:
 
 system-events:
     startup:
-        tutorial: startup
+        tutorial: pipeline.startup
 
 pipelines:
     startup:

--- a/doc/tutorials/twitter/2_oauth/twitter_tutorial/test_processors.py
+++ b/doc/tutorials/twitter/2_oauth/twitter_tutorial/test_processors.py
@@ -14,7 +14,7 @@ class TestTwitterProcessor(processors.StatusTestProcessor):
     name = 'test-twitter'
 
     class TestTwitter(statustest.StatusTestCase):
-        timeout = 2
+        timeout = 4
 
         def setUp(self, auth):
             # if the auth is overridden in our test configuration, pass it on to the process.
@@ -29,17 +29,17 @@ class TestTwitterProcessor(processors.StatusTestProcessor):
         
         @defer.inlineCallbacks
         def statustest_basic_auth(self):
-            output = yield utils.getProcessOutput('piped', args=['-nc', 'twitter.yaml'] + self.auth_override, env=os.environ)
+            output = yield utils.getProcessOutput('piped', args=['-nc', 'twitter.yaml', '-p', 'basic.pid'] + self.auth_override, env=os.environ)
             self.assertIn('Current rate limit status:', output)
 
         @defer.inlineCallbacks
         def statustest_oauth(self):
-            output = yield utils.getProcessOutput('piped', args=['-nc', 'twitter.yaml'] + self.oauth_override, env=os.environ)
+            output = yield utils.getProcessOutput('piped', args=['-nc', 'twitter.yaml', '-p', 'oauth.pid'] + self.oauth_override, env=os.environ)
             self.assertIn('Current rate limit status:', output)
 
         @defer.inlineCallbacks
         def statustest_oauth_dance(self):
-            sub = subprocess.Popen(args=['piped', '-nc', 'twitter.yaml']+self.oauth_without_access_override, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE)
+            sub = subprocess.Popen(args=['piped', '-nc', 'twitter.yaml', '-p', 'oauth_dance.pid']+self.oauth_without_access_override, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE)
 
             while True:
                 line = sub.stdout.readline()

--- a/doc/tutorials/twitter/3_streaming/test_twitter.yaml
+++ b/doc/tutorials/twitter/3_streaming/test_twitter.yaml
@@ -10,7 +10,7 @@ plugins:
 
 system-events:
     startup:
-        test: system-testing
+        test: pipeline.system-testing
 
 pipelines:
     system-testing:

--- a/doc/tutorials/twitter/3_streaming/twitter.yaml
+++ b/doc/tutorials/twitter/3_streaming/twitter.yaml
@@ -20,14 +20,14 @@ twitter:
         streams:
             track_happy:
                 method: filter
-                pipeline: print-status
+                processor: pipeline.print-status
 
                 track:
                     - happy
 
 system-events:
     startup:
-        tutorial: startup
+        tutorial: pipeline.startup
 
 pipelines:
     startup:

--- a/doc/tutorials/twitter/3_streaming/twitter_tutorial/provider.py
+++ b/doc/tutorials/twitter/3_streaming/twitter_tutorial/provider.py
@@ -31,7 +31,8 @@ class MyTwitterProvider(object, service.MultiService):
 
             # create the configured streams:
             for stream_name, stream_config in account_config.get('streams', dict()).items():
-                stream_listener = TwitterStreamListener(auth, **stream_config)
+                name = '%s.%s' % (account_name, stream_name)
+                stream_listener = TwitterStreamListener(name, auth, **stream_config)
                 stream_listener.configure(runtime_environment)
             
                 # the service should be started/stopped when we are:
@@ -74,15 +75,17 @@ class MyTwitterProvider(object, service.MultiService):
 class TwitterStreamListener(tweepy.StreamListener, service.MultiService):
     """ A custom stream listener that feeds statuses into pipelines. """
 
-    def __init__(self, auth, pipeline, method, **method_kwargs):
+    def __init__(self, name, auth, processor, method, **method_kwargs):
         """
         :param auth: A tweepy AuthHandler.
-        :param pipeline: The name of a pipeline.
+        :param processor: The processor name or config.
         :param method: The stream method to use.
         :param method_kwargs: Additional keyword arguments to pass to the method.
         """
         service.MultiService.__init__(self)
         super(TwitterStreamListener, self).__init__()
+
+        self.name = name
 
         # by setting ourselves as the streams service parent, it will be started and
         # stopped when we are.
@@ -94,36 +97,40 @@ class TwitterStreamListener(tweepy.StreamListener, service.MultiService):
         self.method = getattr(self.stream, method)
         self.method(**method_kwargs)
 
-        self.pipeline_name = pipeline
+        # create the dependency config for the processor, and allow the user to use a simple string as the
+        # processor name as a shorthand.
+        self.processor_config = dict(provider=processor) if isinstance(processor, basestring) else processor
 
     def configure(self, runtime_environment):
         dm = runtime_environment.dependency_manager
         # Create a dependency to the pipeline that we will use to process the statuses
-        self.pipeline_dependency = dm.add_dependency(self, dict(provider='pipeline.%s'%self.pipeline_name))
+        self.pipeline_dependency = dm.add_dependency(self, self.processor_config)
 
     def on_status(self, status):
         # on_status is called from outside the twisted reactor mainthread, and we want to process the
         # status inside the reactor:
         reactor.callFromThread(self._process_status, status)
 
+    def on_error(self, status_code):
+        reactor.callFromThread(log.error, 'Twitter api error (%s): %s' % (self.name, status_code))
+        return False
+
     @defer.inlineCallbacks
     def _process_status(self, status):
-        """ We've received a status object from our stream and are now in the main thread
-        of the process.
-        """
+        # We've received a status object from our stream and are now in the main thread of the process.
         # create the baton that will be processed in the pipeline.
         baton = dict(status=status)
 
         # wait for the pipeline to become available, then process the baton
         pipeline = yield self.pipeline_dependency.wait_for_resource()
-        yield pipeline.process(baton)
+        yield pipeline(baton)
 
 
 class TwitterStream(tweepy.Stream, service.Service):
     """ Adapts a tweepy.Stream to a twisted Service. """
 
     def _start(self, async):
-        """ We handle running the request in startService instead. """
+        """ We handle running the request in startService instead, forcing async=True """
 
     @defer.inlineCallbacks
     def startService(self):
@@ -131,7 +138,6 @@ class TwitterStream(tweepy.Stream, service.Service):
         self.running = True
         self.running_service = True
 
-        # continue trying to run as long as the service is running:
         while self.running_service:
             try:
                 yield threads.deferToThread(self._run)

--- a/doc/tutorials/twitter/4_processor/test_twitter.yaml
+++ b/doc/tutorials/twitter/4_processor/test_twitter.yaml
@@ -10,7 +10,7 @@ plugins:
 
 system-events:
     startup:
-        test: system-testing
+        test: pipeline.system-testing
 
 pipelines:
     system-testing:

--- a/doc/tutorials/twitter/4_processor/twitter.yaml
+++ b/doc/tutorials/twitter/4_processor/twitter.yaml
@@ -19,7 +19,7 @@ twitter:
 
 system-events:
     startup:
-        startup: startup
+        startup: pipeline.startup
 
 pipelines:
     startup:

--- a/doc/tutorials/twitter/4_processor/twitter_tutorial/provider.py
+++ b/doc/tutorials/twitter/4_processor/twitter_tutorial/provider.py
@@ -31,7 +31,8 @@ class MyTwitterProvider(object, service.MultiService):
 
             # create the configured streams:
             for stream_name, stream_config in account_config.get('streams', dict()).items():
-                stream_listener = TwitterStreamListener(auth, **stream_config)
+                name = '%s.%s' % (account_name, stream_name)
+                stream_listener = TwitterStreamListener(name, auth, **stream_config)
                 stream_listener.configure(runtime_environment)
             
                 # the service should be started/stopped when we are:
@@ -74,15 +75,17 @@ class MyTwitterProvider(object, service.MultiService):
 class TwitterStreamListener(tweepy.StreamListener, service.MultiService):
     """ A custom stream listener that feeds statuses into pipelines. """
 
-    def __init__(self, auth, pipeline, method, **method_kwargs):
+    def __init__(self, name, auth, processor, method, **method_kwargs):
         """
         :param auth: A tweepy AuthHandler.
-        :param pipeline: The name of a pipeline.
+        :param processor: The processor name or config.
         :param method: The stream method to use.
         :param method_kwargs: Additional keyword arguments to pass to the method.
         """
         service.MultiService.__init__(self)
         super(TwitterStreamListener, self).__init__()
+
+        self.name = name
 
         # by setting ourselves as the streams service parent, it will be started and
         # stopped when we are.
@@ -94,36 +97,40 @@ class TwitterStreamListener(tweepy.StreamListener, service.MultiService):
         self.method = getattr(self.stream, method)
         self.method(**method_kwargs)
 
-        self.pipeline_name = pipeline
+        # create the dependency config for the processor, and allow the user to use a simple string as the
+        # processor name as a shorthand.
+        self.processor_config = dict(provider=processor) if isinstance(processor, basestring) else processor
 
     def configure(self, runtime_environment):
         dm = runtime_environment.dependency_manager
         # Create a dependency to the pipeline that we will use to process the statuses
-        self.pipeline_dependency = dm.add_dependency(self, dict(provider='pipeline.%s'%self.pipeline_name))
+        self.pipeline_dependency = dm.add_dependency(self, self.processor_config)
 
     def on_status(self, status):
         # on_status is called from outside the twisted reactor mainthread, and we want to process the
         # status inside the reactor:
         reactor.callFromThread(self._process_status, status)
 
+    def on_error(self, status_code):
+        reactor.callFromThread(log.error, 'Twitter api error (%s): %s' % (self.name, status_code))
+        return False
+
     @defer.inlineCallbacks
     def _process_status(self, status):
-        """ We've received a status object from our stream and are now in the main thread
-        of the process.
-        """
+        # We've received a status object from our stream and are now in the main thread of the process.
         # create the baton that will be processed in the pipeline.
         baton = dict(status=status)
 
         # wait for the pipeline to become available, then process the baton
         pipeline = yield self.pipeline_dependency.wait_for_resource()
-        yield pipeline.process(baton)
+        yield pipeline(baton)
 
 
 class TwitterStream(tweepy.Stream, service.Service):
     """ Adapts a tweepy.Stream to a twisted Service. """
 
     def _start(self, async):
-        """ We handle running the request in startService instead. """
+        """ We handle running the request in startService instead, forcing async=True """
 
     @defer.inlineCallbacks
     def startService(self):
@@ -131,7 +138,6 @@ class TwitterStream(tweepy.Stream, service.Service):
         self.running = True
         self.running_service = True
 
-        # continue trying to run as long as the service is running:
         while self.running_service:
             try:
                 yield threads.deferToThread(self._run)

--- a/doc/tutorials/twitter/5_markov/test_twitter.yaml
+++ b/doc/tutorials/twitter/5_markov/test_twitter.yaml
@@ -3,7 +3,7 @@ includes:
 
 system-events:
     startup:
-        test: system-testing
+        test: pipeline.system-testing
 
 pipelines:
     system-testing:

--- a/doc/tutorials/twitter/5_markov/twitter.yaml
+++ b/doc/tutorials/twitter/5_markov/twitter.yaml
@@ -21,7 +21,7 @@ twitter:
         streams:
             track_happy:
                 method: filter
-                pipeline: status.tracked
+                processor: pipeline.status.tracked
                 
                 track:
                     - happy
@@ -37,7 +37,7 @@ web:
             # when a user visits /generate, we will generate a tweet
             generate:
                 __config__:
-                    pipeline: web.generate
+                    processor: pipeline.web.generate
 
 
 pipelines:

--- a/doc/tutorials/twitter/5_markov/twitter_tutorial/processors.py
+++ b/doc/tutorials/twitter/5_markov/twitter_tutorial/processors.py
@@ -73,6 +73,10 @@ class MarkovTrainer(base.Processor):
         markov = self.context_dependency.get_resource()
         input = util.dict_get_path(baton, self.input_path)
 
+        # normalize to utf-8:
+        if isinstance(input, unicode):
+            input = input.encode('utf-8')
+
         # word_1 and _2 is two previous words. We use None as sentence start/stop markers.
         word_1, word_2 = None, None
 

--- a/doc/tutorials/twitter/5_markov/twitter_tutorial/test_processors.py
+++ b/doc/tutorials/twitter/5_markov/twitter_tutorial/test_processors.py
@@ -22,7 +22,7 @@ class TestTwitterProcessor(processors.StatusTestProcessor):
         def statustest_status_generated(self):
             test_text = 'this is a tweet'
             fake_status_baton = dict(status=dict(text=test_text), screen_name='test', followers_count='0')
-            yield self.tracked_pipeline.process(fake_status_baton)
+            yield self.tracked_pipeline(fake_status_baton)
 
             page = yield client.getPage('http://localhost:8080/generate')
 

--- a/doc/tutorials/twitter/index.rst
+++ b/doc/tutorials/twitter/index.rst
@@ -191,11 +191,11 @@ the following configuration format for the streams:
 
     twitter:
         <logical-account-name>:
-            # OPTIONAL streams that are processed in a pipeline
+            # OPTIONAL streams that are processed using a processor
             streams:
                 <logical-stream-name>:
                     method: <stream-method>
-                    pipeline: <pipeline-name>
+                    processor: <processor-name>
                     # OPTIONAL keyword arguments to use when creating the stream, for example:
                     track:
                         - new

--- a/piped/dependencies.py
+++ b/piped/dependencies.py
@@ -3,6 +3,7 @@
 """
 This module contains base implementations and managers for the resource system.
 """
+import copy
 import networkx
 from twisted.internet import defer
 from twisted.python import failure, components
@@ -281,7 +282,10 @@ class DictResourceDependencyAdapter(ResourceDependency):
             detail = 'A resource configuration must at least contain the key "provider". The adapter was provided: %r.' % resource_configuration
             raise exceptions.ResourceError(e_msg, detail)
 
+        # copy the resource configuration since we're going to edit it:
+        resource_configuration = copy.copy(resource_configuration)
         provider = resource_configuration.pop('provider')
+
         super(DictResourceDependencyAdapter, self).__init__(provider, resource_configuration, *a, **kw)
 
 

--- a/piped/processing.py
+++ b/piped/processing.py
@@ -466,6 +466,9 @@ class TwistedProcessorGraphEvaluator(object):
 
         defer.returnValue(results)
 
+    # Calling the evaluator directly should be the same as starting to process a baton in a pipeline:
+    __call__ = process
+
     @defer.inlineCallbacks
     def traced_process(self, *a, **kw):
         """ Traces and processes a baton asynchronously through a processor graph.

--- a/piped/processing.py
+++ b/piped/processing.py
@@ -525,7 +525,7 @@ class ProcessorGraphFactory(object):
         self.pipelines_configuration = self._get_pipeline_configuration(runtime_environment)
 
         if not self.pipelines_configuration:
-            log.warn('Could not find any pipeline definitions in the configuration.')
+            log.info('No pipeline definitions were found in the configuration.')
 
         self.plugin_manager = ProcessorPluginManager()
         self.plugin_manager.configure(runtime_environment)

--- a/piped/processing.py
+++ b/piped/processing.py
@@ -548,7 +548,7 @@ class ProcessorGraphFactory(object):
         # attempt to convert the configuration to a base format before checking if it is a valid configuration.
         config = self._as_processor_configuration(maybe_configuration)
         if isinstance(config, dict):
-            if 'processor' in config or 'inline-pipeline' in config:
+            if '__processor__' in config or 'inline-pipeline' in config:
                 return True
         return False
 
@@ -635,7 +635,7 @@ class ProcessorGraphFactory(object):
 
         Processors can be defined in several ways, the base format being:
 
-            processor: processor-name
+            __processor__: processor-name
             key1: value1
             key2: value2
 
@@ -661,10 +661,10 @@ class ProcessorGraphFactory(object):
 
         if isinstance(processor_configuration, basestring):
             # if it is a string, we assume it is the name of a processor
-            return dict(processor=processor_configuration)
+            return dict(__processor__=processor_configuration)
 
         if isinstance(processor_configuration, dict):
-            if 'processor' in processor_configuration or 'inline-pipeline' in processor_configuration:
+            if '__processor__' in processor_configuration or 'inline-pipeline' in processor_configuration:
                 # it is already a processor configuration
                 return processor_configuration
 
@@ -684,7 +684,7 @@ class ProcessorGraphFactory(object):
             del processor_configuration[processor_name]
 
             # update the processor name and configuration
-            processor_configuration['processor'] = processor_name
+            processor_configuration['__processor__'] = processor_name
             processor_configuration.update(processor_arguments)
 
             return processor_configuration
@@ -698,7 +698,7 @@ class ProcessorGraphFactory(object):
     def _fail_if_pipeline_is_misconfigured(cls, pipeline):
         # the pipeline configuration might not be iterable...
         if isinstance(pipeline, collections.Iterable):
-            if any(key in pipeline for key in ('processor', 'inline-pipeline', 'chained_consumers', 'consumers', 'existing')):
+            if any(key in pipeline for key in ('__processor__', 'inline-pipeline', 'chained_consumers', 'consumers', 'existing')):
                 return
 
         e_msg = 'invalid contents of pipeline-configuration'
@@ -743,7 +743,7 @@ class ProcessorGraphFactory(object):
                 # Sub-pipelines can be nested in sub-consumers.
                 self._flatten_pipeline(pipeline_name, attribute)
 
-                if 'processor' in attribute or 'existing' in attribute:
+                if '__processor__' in attribute or 'existing' in attribute:
                     attribute_after_flattening.append(attribute)
                     # Any potential sub-pipelines in consumers have been flattened above,
                     # so we're done here.
@@ -849,7 +849,7 @@ class ProcessorGraphFactory(object):
             processor_queue.extendleft(current_processor.get('error_consumers', tuple()))
 
             next_in_queue = overrides[0] # Peek
-            if current_processor['processor'] == next_in_queue['processor']:
+            if current_processor['__processor__'] == next_in_queue['__processor__']:
                 cls._override_processor_options(current_processor, overrides.popleft())
 
         cls._fail_if_not_all_overrides_were_used(overrides, pipeline_name)
@@ -905,7 +905,7 @@ class ProcessorGraphFactory(object):
         if not overrides:
             return
 
-        names_of_processors = [override['processor'] for override in overrides]
+        names_of_processors = [override['__processor__'] for override in overrides]
         e_msg = 'overrides provided but not used: %s' % (names_of_processors, )
         detail = ('The pipeline "%s" was provided with overrides to processors not found in the pipeline it '
                   'inherited from.') % (pipeline_name, )
@@ -947,7 +947,7 @@ class ProcessorGraphFactory(object):
 
         # We pop away stuff because we want the remaining dictionary to define the
         # configuration values.
-        plugin_name = copied_processor_configuration.pop('processor')
+        plugin_name = copied_processor_configuration.pop('__processor__')
         processor_id = copied_processor_configuration.pop('id', None)
 
         plugin_factory = self._get_plugin_factory_or_fail(plugin_name)

--- a/piped/processors/pipeline_processors.py
+++ b/piped/processors/pipeline_processors.py
@@ -62,7 +62,7 @@ class ScatterGatherer(base.Processor):
 
             input_baton = self.preprocess_baton(self._maybe_copy(input_baton))
 
-            d = defer.maybeDeferred(pipeline.process, input_baton)
+            d = defer.maybeDeferred(pipeline, input_baton)
             d.addCallback(lambda _, resulting_baton=input_baton, output_path=output_path: util.dict_set_path(baton, output_path, resulting_baton))
 
             ds.append(d)
@@ -202,7 +202,7 @@ class PipelineRunner(base.InputOutputProcessor):
             results, trace = yield pipeline.traced_process(input)
             util.dict_set_path(baton, self.trace_path, trace)
         else:
-            results = yield pipeline.process(input)
+            results = yield pipeline(input)
 
         if hasattr(results, '__getitem__') and self.only_last_result:
             results = results[-1]
@@ -376,7 +376,7 @@ class ForEach(base.InputOutputProcessor):
         for sub_baton in input:
 
             try:
-                result = yield pipeline.process(sub_baton)
+                result = yield pipeline(sub_baton)
                 results.append(self.result_processor(result))
             except Exception:
                 if self.fail_on_error:
@@ -403,7 +403,7 @@ class ForEach(base.InputOutputProcessor):
 
         # Prepare running all pipelines in parallel.
         for sub_baton in input:
-            d = defer.maybeDeferred(pipeline.process, sub_baton)
+            d = defer.maybeDeferred(pipeline, sub_baton)
             # ... the result must be processed as usual.
             d.addCallback(lambda result: self.result_processor(result))
             ds.append(d)

--- a/piped/processors/test/test_smtp_processors.py
+++ b/piped/processors/test/test_smtp_processors.py
@@ -17,7 +17,7 @@ class FakePipeline(object):
         self.batons = defer.DeferredQueue()
         self.i = 0
 
-    def process(self, baton):
+    def __call__(self, baton):
         self.batons.put(baton)
         self.i += 1
         return [self.i]
@@ -38,7 +38,7 @@ class SendEmailTest(test_smtp_provider.SMTPServerTestBase):
     @defer.inlineCallbacks
     def test_sending_an_email(self):
         self.create_smtp_server()
-        self.server.pipeline_dependency = self.pipeline_dependency
+        self.server.processor_dependency = self.pipeline_dependency
 
         self.server.startService()
         self.addCleanup(self.server.stopService)
@@ -53,7 +53,7 @@ class SendEmailTest(test_smtp_provider.SMTPServerTestBase):
     @defer.inlineCallbacks
     def test_valid_from_to_formats(self):
         self.create_smtp_server()
-        self.server.pipeline_dependency = self.pipeline_dependency
+        self.server.processor_dependency = self.pipeline_dependency
 
         self.server.startService()
         self.addCleanup(self.server.stopService)

--- a/piped/processors/test/test_tick_processors.py
+++ b/piped/processors/test/test_tick_processors.py
@@ -37,14 +37,14 @@ class TickProcessorTest(unittest.TestCase):
         self.runtime_environment.application.stopService()
 
     def add_consumer(self, resource_dependency):
-        resource_dependency.on_resource_ready(self)
+        resource_dependency.on_resource_ready(self.process)
 
     def process(self, baton):
         return self.ticks.put(baton)
 
     @defer.inlineCallbacks
     def test_starting_an_interval(self):
-        self.intervals['test_interval'] = dict(interval=0, auto_start=False, pipeline='test_pipeline')
+        self.intervals['test_interval'] = dict(interval=0, auto_start=False, processor='pipeline.test_pipeline')
 
         self.provider.configure(self.runtime_environment)
         self.start_processor.configure(self.runtime_environment)
@@ -60,7 +60,7 @@ class TickProcessorTest(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_stopping_an_interval(self):
-        self.intervals['test_interval'] = dict(interval=0, pipeline='test_pipeline')
+        self.intervals['test_interval'] = dict(interval=0, processor='pipeline.test_pipeline')
 
         self.provider.configure(self.runtime_environment)
         self.stop_processor.configure(self.runtime_environment)
@@ -77,7 +77,7 @@ class TickProcessorTest(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_restarting_an_interval(self):
-        self.intervals['test_interval'] = dict(interval=0, auto_start=False, pipeline='test_pipeline')
+        self.intervals['test_interval'] = dict(interval=0, auto_start=False, processor='pipeline.test_pipeline')
 
         self.provider.configure(self.runtime_environment)
         self.start_processor.configure(self.runtime_environment)

--- a/piped/providers/pipeline_provider.py
+++ b/piped/providers/pipeline_provider.py
@@ -82,7 +82,9 @@ class PipelineProvider(object):
         pipeline_dependency = self.dependency_manager.as_dependency(pipeline)
 
         # Give the resource_dependency the actual pipeline resource
-        pipeline_dependency.on_ready += lambda dependency: resource_dependency.on_resource_ready(pipeline)
+        resource = pipeline
+
+        pipeline_dependency.on_ready += lambda dependency: resource_dependency.on_resource_ready(resource)
         pipeline_dependency.on_lost += lambda dependency, reason: resource_dependency.on_resource_lost(reason)
 
         # this isn't strictly required, but makes for an easier graph to follow
@@ -91,4 +93,4 @@ class PipelineProvider(object):
         # if the pipeline already is ready, the on_ready will not be called later, and we give
         # the resource dependency the pipeline immediately
         if pipeline_dependency.is_ready:
-            resource_dependency.on_resource_ready(pipeline)
+            resource_dependency.on_resource_ready(resource)

--- a/piped/providers/test/test_pipeline_provider.py
+++ b/piped/providers/test/test_pipeline_provider.py
@@ -25,4 +25,8 @@ class PipelineProviderTest(unittest.TestCase):
         self.dependency_manager.resolve_initial_states()
 
         self.assertEquals(pipeline_provider_dependency.get_resource(), pp)
-        self.assertIsInstance(pipeline_dependency.get_resource(), processing.TwistedProcessorGraphEvaluator)
+
+        processor = pipeline_dependency.get_resource()
+        self.assertTrue(hasattr(processor, '__call__'))
+        self.assertEquals(processor.__call__.im_func.func_name, 'process')
+        self.assertIsInstance(processor, processing.TwistedProcessorGraphEvaluator)

--- a/piped/providers/test/test_process_provider.py
+++ b/piped/providers/test/test_process_provider.py
@@ -70,8 +70,8 @@ class DefaultProcessProtocolTest(unittest.TestCase):
         protocol_config.setdefault('provider', None)
         protocol_config.setdefault('process_name', 'test')
         protocol_config.setdefault('executable', None)
-        protocol_config.setdefault('stdout', dict(pipeline='FAKE'))
-        protocol_config.setdefault('stderr', dict(pipeline='FAKE'))
+        protocol_config.setdefault('stdout', dict(processor='FAKE'))
+        protocol_config.setdefault('stderr', dict(processor='FAKE'))
 
         return process_provider.DefaultProcessProtocol(**protocol_config)
 
@@ -108,7 +108,7 @@ class DefaultProcessProtocolTest(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_custom_delimiter(self):
-        protocol = self._make_protocol(stdout=dict(delimiter='e', pipeline='FAKE'))
+        protocol = self._make_protocol(stdout=dict(delimiter='e', processor='FAKE'))
         stdout = self._make_baton_collector(protocol.stdout_protocol)
 
         data = 'the quick brown fox jumps over the lazy dog'

--- a/piped/providers/test/test_spread_provider.py
+++ b/piped/providers/test/test_spread_provider.py
@@ -312,7 +312,7 @@ class PBClientTest(PBTestBase):
 
         self.create_pb_server()
         cm.set('pb.clients.test_client.endpoint', 'tcp:host=localhost:port=%i'%self.port)
-        cm.set('pipelines.test_pipeline', [{'processor':'eval-lambda', 'lambda': 'baton: baton["deferred"].callback("foo")'}])
+        cm.set('pipelines.test_pipeline', [{'eval-lambda': {'lambda': 'baton: baton["deferred"].callback("foo")'}}])
         pp = pipeline_provider.PipelineProvider()
         pp.configure(self.runtime_environment)
 
@@ -384,7 +384,7 @@ class PBClientTest(PBTestBase):
             password = 'test_password'
         ))
 
-        cm.set('pipelines.test_pipeline', [{'processor':'eval-lambda', 'lambda': 'baton: baton["deferred"].callback("logged in as %s"%baton["avatar_id"])'}])
+        cm.set('pipelines.test_pipeline', [{'eval-lambda': {'lambda': 'baton: baton["deferred"].callback("logged in as %s"%baton["avatar_id"])'}}])
         pp = pipeline_provider.PipelineProvider()
         pp.configure(self.runtime_environment)
 
@@ -456,7 +456,7 @@ class PBClientTest(PBTestBase):
             endpoint = 'tcp:host=localhost:port=%i'%self.port,
         ))
 
-        cm.set('pipelines.test_pipeline', [{'processor':'eval-lambda', 'lambda': 'baton: baton["deferred"].callback("logged in as %s"%baton["avatar_id"])'}])
+        cm.set('pipelines.test_pipeline', [{'eval-lambda': {'lambda': 'baton: baton["deferred"].callback("logged in as %s"%baton["avatar_id"])'}}])
         pp = pipeline_provider.PipelineProvider()
         pp.configure(self.runtime_environment)
 

--- a/piped/providers/test/test_system_events_provider.py
+++ b/piped/providers/test/test_system_events_provider.py
@@ -9,10 +9,10 @@ from piped.providers import system_events_provider
 
 class StubPipelineProvider(object):
     def __init__(self, collector):
-        self.process = collector
+        self.processor = collector
 
     def add_consumer(self, resource_dependency):
-        resource_dependency.on_resource_ready(self)
+        resource_dependency.on_resource_ready(self.processor)
 
 
 class SystemEventsProviderTest(unittest.TestCase):
@@ -32,7 +32,7 @@ class SystemEventsProviderTest(unittest.TestCase):
         configuration_manager = self.runtime_environment.configuration_manager
 
         for event_type in 'startup', 'shutdown':
-            configuration_manager.set('system-events.%s.name' % event_type, 'test_pipeline')
+            configuration_manager.set('system-events.%s.name' % event_type, 'pipeline.test_pipeline')
 
         provider.configure(self.runtime_environment)
 
@@ -43,6 +43,6 @@ class SystemEventsProviderTest(unittest.TestCase):
         self.assertEquals(batons, [dict(event_type='startup')])
         batons[:] = list()
 
-        # trigger the shutdown event, which should give our pipeline a baton
+        # trigger the shutdown event, which should give our processor a baton
         reactor.fireSystemEvent('shutdown')
         self.assertEquals(batons, [dict(event_type='shutdown')])

--- a/piped/test/test_processing.py
+++ b/piped/test/test_processing.py
@@ -1379,9 +1379,9 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
                 ]
             )
             # These should not be recognized as pipeline configurations at all..
-            with patch.object(processing.log, 'warn') as mocked_warn:
+            with patch.object(processing.log, 'info') as mocked_info:
                 self.assertConfigurationProperlyTransformed(invalid_pipeline_configuration, dict(), reason)
-                self.assertEquals(mocked_warn.call_count, 1)
+                self.assertEquals(mocked_info.call_args_list, [(('No pipeline definitions were found in the configuration.',), {})])
 
     def test_rewriting_invalid_processor_when_in_pipeline(self):
 

--- a/piped/test/test_processing.py
+++ b/piped/test/test_processing.py
@@ -2040,8 +2040,8 @@ class TwistedEvaluatorTest(ProcessorGraphTest):
             def __init__(self, evaluator):
                 self.evaluator = evaluator
 
-            def process(self, baton):
-                return self.evaluator.process(baton)
+            def __call__(self, baton):
+                return self.evaluator(baton)
 
         nested_evaluator_proxy = EvaluatorProxy(nested_evaluator)
 

--- a/piped/test/test_processing.py
+++ b/piped/test/test_processing.py
@@ -138,7 +138,7 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
             possibilities.append(processor_name)
 
         possibilities.append({processor_name:dict(processor_kwargs)})
-        possibilities.append(dict(processor=processor_name, **processor_kwargs))
+        possibilities.append(dict(__processor__=processor_name, **processor_kwargs))
 
         return possibilities
 
@@ -149,8 +149,8 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'uppercase'},
-                    {'processor': 'reverse'},
+                    {'__processor__': 'uppercase'},
+                    {'__processor__': 'reverse'},
                 ]
             }
         }
@@ -175,7 +175,7 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'any', u'æøå':'value'},
+                    {'__processor__': 'any', u'æøå':'value'},
                 ]
             }
         }
@@ -192,7 +192,7 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'raise-exception'},
+                    {'__processor__': 'raise-exception'},
                 ]
             }
         }
@@ -217,11 +217,11 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'raise-exception'},
-                    {'processor': 'uppercase'},
+                    {'__processor__': 'raise-exception'},
+                    {'__processor__': 'uppercase'},
                 ],
                 'chained_error_consumers': [
-                    {'processor': 'reverse'},
+                    {'__processor__': 'reverse'},
                 ]
             }
         }
@@ -248,11 +248,11 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'raise-exception'},
-                    {'processor': 'uppercase'},
+                    {'__processor__': 'raise-exception'},
+                    {'__processor__': 'uppercase'},
                 ],
                 'error_consumers': [
-                    {'processor': 'reverse'},
+                    {'__processor__': 'reverse'},
                 ],
             }
         }
@@ -280,15 +280,15 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'raise-exception'},
-                    {'processor': 'uppercase'},
+                    {'__processor__': 'raise-exception'},
+                    {'__processor__': 'uppercase'},
                 ],
                 'chained_error_consumers':[
-                    {'processor': 'reverse'},
-                    {'processor': 'uppercase'},
+                    {'__processor__': 'reverse'},
+                    {'__processor__': 'uppercase'},
                 ],
                 'error_consumers': [
-                    {'processor': 'reverse'},
+                    {'__processor__': 'reverse'},
                 ],
             }
         }
@@ -315,11 +315,11 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'uppercase'},
-                    {'processor': 'reverse'},
+                    {'__processor__': 'uppercase'},
+                    {'__processor__': 'reverse'},
                 ],
                 'chained_error_consumers': [
-                    {'processor': 'raise-exception'},
+                    {'__processor__': 'raise-exception'},
                 ]
             }
         }
@@ -348,10 +348,10 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
             'only-pipeline': {
                     'consumers': [
                         {
-                            'processor': 'reverse',
+                            '__processor__': 'reverse',
                             'consumers': [
-                                {'processor': 'uppercase'},
-                                {'processor': 'lowercase'},
+                                {'__processor__': 'uppercase'},
+                                {'__processor__': 'lowercase'},
                             ]
                         }
                     ]
@@ -381,8 +381,8 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'consumers': [
-                    {'processor': 'uppercase'},
-                    {'processor': 'lowercase'},
+                    {'__processor__': 'uppercase'},
+                    {'__processor__': 'lowercase'},
                 ]
             }
         }
@@ -412,13 +412,13 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
             'only-pipeline': {
                 'consumers': [
                     {
-                        'processor': 'uppercase',
+                        '__processor__': 'uppercase',
                         'consumers': [
-                            {'processor': 'reverse', 'id': 'reuse_me'},
+                            {'__processor__': 'reverse', 'id': 'reuse_me'},
                         ]
                     },
                     {
-                        'processor': 'lowercase',
+                        '__processor__': 'lowercase',
                         'consumers': [{'existing': 'reuse_me'}]
                     }
                 ]
@@ -444,14 +444,14 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'reverse-and-uppercase': {
                 'chained_consumers': [
-                    {'processor': 'reverse'},
-                    {'processor': 'uppercase'},
+                    {'__processor__': 'reverse'},
+                    {'__processor__': 'uppercase'},
                 ]
             },
             'reverse-and-lowercase': {
                 'chained_consumers': [
-                    {'processor': 'reverse'},
-                    {'processor': 'lowercase'},
+                    {'__processor__': 'reverse'},
+                    {'__processor__': 'lowercase'},
                 ]
             },
             'use-the-others': {
@@ -465,32 +465,32 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         expected_pipeline_configuration = {
             'reverse-and-uppercase': {
                 'consumers': [
-                    {'processor': 'reverse',
+                    {'__processor__': 'reverse',
                      'consumers': [
-                            {'processor': 'uppercase'},
+                            {'__processor__': 'uppercase'},
                         ]
                     }
                 ]
             },
             'reverse-and-lowercase': {
                 'consumers': [
-                    {'processor': 'reverse',
+                    {'__processor__': 'reverse',
                      'consumers': [
-                            {'processor': 'lowercase'},
+                            {'__processor__': 'lowercase'},
                         ]
                     }
                 ]
             },
             'use-the-others': {
                  'consumers': [
-                    {'processor': 'reverse',
+                    {'__processor__': 'reverse',
                      'consumers': [
-                            {'processor': 'uppercase'},
+                            {'__processor__': 'uppercase'},
                         ]
                     },
-                    {'processor': 'reverse',
+                    {'__processor__': 'reverse',
                      'consumers': [
-                            {'processor': 'lowercase'},
+                            {'__processor__': 'lowercase'},
                         ]
                     }
                 ]
@@ -504,16 +504,16 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'reverse-and-uppercase': {
                 'chained_consumers': [
-                    {'processor': 'reverse'},
-                    {'processor': 'uppercase'},
+                    {'__processor__': 'reverse'},
+                    {'__processor__': 'uppercase'},
                 ]
             },
             'reverse-and-lowercase': {
                 'chained_consumers': [
-                    {'processor': 'reverse'},
-                    {'processor': 'lowercase'},
+                    {'__processor__': 'reverse'},
+                    {'__processor__': 'lowercase'},
                 ],
-                'chained_error_consumers': [{'processor': 'reverse'}],
+                'chained_error_consumers': [{'__processor__': 'reverse'}],
             },
             'use-the-others': {
                  'consumers': [
@@ -526,35 +526,35 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         expected_pipeline_configuration = {
             'reverse-and-uppercase': {
                 'consumers': [
-                    {'processor': 'reverse',
+                    {'__processor__': 'reverse',
                      'consumers': [
-                            {'processor': 'uppercase'},
+                            {'__processor__': 'uppercase'},
                         ]
                     }
                 ]
             },
             'reverse-and-lowercase': {
                 'consumers': [
-                    {'processor': 'reverse',
+                    {'__processor__': 'reverse',
                      'consumers': [
-                            {'processor': 'lowercase'},
+                            {'__processor__': 'lowercase'},
                         ],
-                     'error_consumers': [{'processor': 'reverse'}],
+                     'error_consumers': [{'__processor__': 'reverse'}],
                     }
                 ]
             },
             'use-the-others': {
                  'consumers': [
-                    {'processor': 'reverse',
+                    {'__processor__': 'reverse',
                      'consumers': [
-                            {'processor': 'uppercase'},
+                            {'__processor__': 'uppercase'},
                         ]
                     },
-                    {'processor': 'reverse',
+                    {'__processor__': 'reverse',
                      'consumers': [
-                            {'processor': 'lowercase'},
+                            {'__processor__': 'lowercase'},
                         ],
-                     'error_consumers': [{'processor': 'reverse'}],
+                     'error_consumers': [{'__processor__': 'reverse'}],
                     }
                 ]
             },
@@ -568,14 +568,14 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'reverse-and-uppercase': {
                 'chained_consumers': [
-                    {'processor': 'reverse'},
-                    {'processor': 'uppercase'},
+                    {'__processor__': 'reverse'},
+                    {'__processor__': 'uppercase'},
                 ]
             },
             'consume-the-other': {
                  'chained_consumers': [
                     {'inline-pipeline': 'reverse-and-uppercase'},
-                    {'processor': 'reverse'},
+                    {'__processor__': 'reverse'},
                 ]
             },
         }
@@ -583,19 +583,19 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         expected_pipeline_configuration = {
             'reverse-and-uppercase': {
                 'consumers': [
-                    {'processor': 'reverse',
+                    {'__processor__': 'reverse',
                      'consumers': [
-                            {'processor': 'uppercase'},
+                            {'__processor__': 'uppercase'},
                         ]
                     }
                 ]
             },
             'consume-the-other': {
                 'consumers': [
-                    {'processor': 'reverse',
+                    {'__processor__': 'reverse',
                      'consumers': [
-                            {'processor': 'uppercase',
-                             'consumers': [{'processor': 'reverse'}]},
+                            {'__processor__': 'uppercase',
+                             'consumers': [{'__processor__': 'reverse'}]},
                         ]
                     }
                 ]
@@ -609,14 +609,14 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'reverse-and-uppercase': {
                 'chained_consumers': [
-                    {'processor': 'reverse-in-pipeline'},
-                    {'processor': 'uppercase'},
+                    {'__processor__': 'reverse-in-pipeline'},
+                    {'__processor__': 'uppercase'},
                 ]
             },
             'consume-the-other': {
                  'chained_consumers': [
                     {'inline-pipeline': 'reverse-and-uppercase'},
-                    {'processor': 'reverse'},
+                    {'__processor__': 'reverse'},
                  ],
                  'chained_error_consumers': [{'inline-pipeline':'reverse-and-uppercase'}]
             },
@@ -625,24 +625,24 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         expected_pipeline_configuration = {
             'reverse-and-uppercase': {
                 'consumers': [
-                    {'processor': 'reverse-in-pipeline',
+                    {'__processor__': 'reverse-in-pipeline',
                      'consumers': [
-                            {'processor': 'uppercase'},
+                            {'__processor__': 'uppercase'},
                         ]
                     }
                 ]
             },
             'consume-the-other': {
                 'consumers': [
-                    {'processor': 'reverse-in-pipeline',
+                    {'__processor__': 'reverse-in-pipeline',
                      'consumers': [
-                            {'processor': 'uppercase',
-                             'consumers': [{'processor': 'reverse'}]},
+                            {'__processor__': 'uppercase',
+                             'consumers': [{'__processor__': 'reverse'}]},
                        ],
                      'error_consumers': [
-                         {'processor': 'reverse-in-pipeline',
+                         {'__processor__': 'reverse-in-pipeline',
                           'consumers': [
-                                 {'processor': 'uppercase'},
+                                 {'__processor__': 'uppercase'},
                              ]
                          }
                      ]
@@ -660,37 +660,37 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
             'A': {
                 'chained_consumers': [
                     {'inline-pipeline': 'B'},
-                    {'processor': 'P1'},
+                    {'__processor__': 'P1'},
                 ]
             },
             'B': {
                  'chained_consumers': [
-                    {'processor': 'P2'},
+                    {'__processor__': 'P2'},
                     {'inline-pipeline': 'C'},
                 ]
             },
             'C': {
-                'consumers': [{'processor': 'P3'}],
+                'consumers': [{'__processor__': 'P3'}],
             }
         }
 
         expected_pipeline_configuration = {
             'A': {
                  'consumers': [
-                    {'processor': 'P2',
-                     'consumers': [{'processor': 'P3',
+                    {'__processor__': 'P2',
+                     'consumers': [{'__processor__': 'P3',
                                     'consumers': [
-                                    {'processor': 'P1'}]}]
+                                    {'__processor__': 'P1'}]}]
                     }]
             },
             'B': {
                  'consumers': [
-                    {'processor': 'P2',
-                     'consumers': [{'processor': 'P3'}]}
+                    {'__processor__': 'P2',
+                     'consumers': [{'__processor__': 'P3'}]}
                 ]
             },
             'C': {
-                'consumers': [{'processor': 'P3'}],
+                'consumers': [{'__processor__': 'P3'}],
             }
         }
 
@@ -716,17 +716,17 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
             'A': {
                 'chained_consumers': [
                     {'inline-pipeline': 'B'},
-                    {'processor': 'P1'},
+                    {'__processor__': 'P1'},
                 ]
             },
             'B': {
                  'chained_consumers': [
-                    {'processor': 'P2'},
+                    {'__processor__': 'P2'},
                     {'inline-pipeline': 'C'},
                 ]
             },
             'C': {
-                'consumers': [{'processor': 'P3'}],
+                'consumers': [{'__processor__': 'P3'}],
             },
             'D': {
                 'chained_consumers': [
@@ -735,24 +735,24 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
                     },
                 ],
                 'chained_error_consumers': [
-                    {'processor': 'D-handler'}
+                    {'__processor__': 'D-handler'}
                 ]
             },
             'E': {
                 'consumers': [
-                    {'processor': 'solo-e'},
+                    {'__processor__': 'solo-e'},
                     {
-                        'processor': 'E1',
-                        'error_consumers': [{'processor': 'E1-fail-handler'}],
+                        '__processor__': 'E1',
+                        'error_consumers': [{'__processor__': 'E1-fail-handler'}],
                         'consumers': [{'inline-pipeline': 'D'}],
                     }
                 ]
             },
             'F': {
                 'consumers': [
-                    {'processor': 'solo-f'},
+                    {'__processor__': 'solo-f'},
                     {
-                        'processor': 'F1',
+                        '__processor__': 'F1',
                         'error_consumers': [{'inline-pipeline': 'E'}],
                         'consumers': [{'inline-pipeline': 'D'}],
                     }
@@ -763,46 +763,46 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         expected_pipeline_configuration = {
             'A': {
                  'consumers': [
-                    {'processor': 'P2',
-                     'consumers': [{'processor': 'P3',
+                    {'__processor__': 'P2',
+                     'consumers': [{'__processor__': 'P3',
                                     'consumers': [
-                                    {'processor': 'P1'}]}]
+                                    {'__processor__': 'P1'}]}]
                     }]
             },
             'B': {
                  'consumers': [
-                    {'processor': 'P2',
-                     'consumers': [{'processor': 'P3'}]}
+                    {'__processor__': 'P2',
+                     'consumers': [{'__processor__': 'P3'}]}
                 ]
             },
             'C': {
-                'consumers': [{'processor': 'P3'}],
+                'consumers': [{'__processor__': 'P3'}],
             },
             'D': {
                 'consumers': [
                     {
-                        'processor': 'P3',
+                        '__processor__': 'P3',
                         'error_consumers': [
-                            {'processor':'D-handler'}
+                            {'__processor__':'D-handler'}
                         ]
                     }
                 ]
             },
             'E': {
                 'consumers': [
-                    {'processor': 'solo-e'},
+                    {'__processor__': 'solo-e'},
                     {
-                        'processor': 'E1',
+                        '__processor__': 'E1',
                         'error_consumers': [
                             {
-                                'processor': 'E1-fail-handler',
+                                '__processor__': 'E1-fail-handler',
                             }
                         ],
                         'consumers': [
                             {
-                                'processor': 'P3',
+                                '__processor__': 'P3',
                                 'error_consumers': [
-                                    {'processor':'D-handler'}
+                                    {'__processor__':'D-handler'}
                                 ]
                             }
                         ]
@@ -811,23 +811,23 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
             },
             'F': {
                 'consumers': [
-                    {'processor': 'solo-f'},
+                    {'__processor__': 'solo-f'},
                     {
-                        'processor': 'F1',
+                        '__processor__': 'F1',
                         'error_consumers': [
-                            {'processor': 'solo-e'},
+                            {'__processor__': 'solo-e'},
                             {
-                                'processor': 'E1',
+                                '__processor__': 'E1',
                                 'error_consumers': [
                                     {
-                                        'processor': 'E1-fail-handler',
+                                        '__processor__': 'E1-fail-handler',
                                     }
                                 ],
                                 'consumers': [
                                     {
-                                        'processor': 'P3',
+                                        '__processor__': 'P3',
                                         'error_consumers': [
-                                            {'processor':'D-handler'}
+                                            {'__processor__':'D-handler'}
                                         ]
                                     }
                                 ]
@@ -835,9 +835,9 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
                         ],
                         'consumers': [
                             {
-                                'processor': 'P3',
+                                '__processor__': 'P3',
                                 'error_consumers': [
-                                    {'processor':'D-handler'}
+                                    {'__processor__':'D-handler'}
                                 ]
                             }
                         ]
@@ -853,10 +853,10 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'included-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'do-something'}
+                    {'__processor__': 'do-something'}
                 ],
                 'chained_error_consumers': [
-                    {'processor': 'handle-error'},
+                    {'__processor__': 'handle-error'},
                 ],
             },
             'some-pipeline': {
@@ -864,7 +864,7 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
                     {'inline-pipeline': 'included-pipeline'}
                 ],
                 'chained_error_consumers': [
-                    {'processor': 'some-error-consumer'},
+                    {'__processor__': 'some-error-consumer'},
                 ],
             }
         }
@@ -873,16 +873,16 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
             'included-pipeline': {
                 'consumers': [
                     {
-                        'processor': 'do-something',
-                        'error_consumers': [{'processor': 'handle-error'}],
+                        '__processor__': 'do-something',
+                        'error_consumers': [{'__processor__': 'handle-error'}],
                     },
                 ]
             },
             'some-pipeline': {
                 'consumers': [
                     {
-                        'processor': 'do-something',
-                        'error_consumers': [{'processor': 'handle-error'}, {'processor': 'some-error-consumer'}],
+                        '__processor__': 'do-something',
+                        'error_consumers': [{'__processor__': 'handle-error'}, {'__processor__': 'some-error-consumer'}],
                     }
                 ]
             }
@@ -894,11 +894,11 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'my-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'do-something'}
+                    {'__processor__': 'do-something'}
                 ],
                 'chained_error_consumers': [
-                    {'processor': 'handle-error'},
-                    {'processor': 'assume-error-is-handled'}
+                    {'__processor__': 'handle-error'},
+                    {'__processor__': 'assume-error-is-handled'}
                 ],
             },
         }
@@ -907,12 +907,12 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
             'my-pipeline': {
                 'consumers': [
                     {
-                        'processor': 'do-something',
+                        '__processor__': 'do-something',
                         'error_consumers': [
                             {
-                                'processor': 'handle-error',
+                                '__processor__': 'handle-error',
                                 'consumers': [
-                                    {'processor': 'assume-error-is-handled'}
+                                    {'__processor__': 'assume-error-is-handled'}
                                 ],
                             }
                         ],
@@ -929,14 +929,14 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'reverse-and-uppercase': {
                 'consumers': [ # Diff to previous test, these are not chained.
-                    {'processor': 'reverse'},
-                    {'processor': 'uppercase'},
+                    {'__processor__': 'reverse'},
+                    {'__processor__': 'uppercase'},
                 ]
             },
             'consume-the-other': {
                  'chained_consumers': [
                     {'inline-pipeline': 'reverse-and-uppercase'},
-                    {'processor': 'reverse'},
+                    {'__processor__': 'reverse'},
                 ]
             },
         }
@@ -944,16 +944,16 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         expected_pipeline_configuration = {
             'reverse-and-uppercase': {
                 'consumers': [
-                    {'processor': 'reverse'},
-                    {'processor': 'uppercase'},
+                    {'__processor__': 'reverse'},
+                    {'__processor__': 'uppercase'},
                 ]
             },
             'consume-the-other': {
                 'consumers': [
-                    {'processor': 'reverse',
-                     'consumers': [{'processor': 'reverse'}]},
-                    {'processor': 'uppercase',
-                     'consumers': [{'processor': 'reverse'}]},
+                    {'__processor__': 'reverse',
+                     'consumers': [{'__processor__': 'reverse'}]},
+                    {'__processor__': 'uppercase',
+                     'consumers': [{'__processor__': 'reverse'}]},
                 ]
             },
         }
@@ -965,8 +965,8 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'some-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'A'},
-                    {'processor': 'B'},
+                    {'__processor__': 'A'},
+                    {'__processor__': 'B'},
                 ]
             }
         }
@@ -974,9 +974,9 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         expected_pipeline_configuration = {
             'some-pipeline': {
                 'consumers': [
-                    {'processor': 'A',
+                    {'__processor__': 'A',
                      'consumers': [
-                            {'processor': 'B'},
+                            {'__processor__': 'B'},
                     ]}
                 ]
             }
@@ -993,16 +993,16 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'some-pipeline': {
                 'consumers': [
-                    {'processor': 'C'},
+                    {'__processor__': 'C'},
                 ],
                 'chained_consumers': [
-                    {'processor': 'A',
-                     'consumers': [{'processor':'D'}]
+                    {'__processor__': 'A',
+                     'consumers': [{'__processor__':'D'}]
                     },
-                    {'processor': 'B',
+                    {'__processor__': 'B',
                      'chained_consumers': [
-                            {'processor': 'E'},
-                            {'processor': 'F'},
+                            {'__processor__': 'E'},
+                            {'__processor__': 'F'},
                         ]
                     },
                 ]
@@ -1012,18 +1012,18 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         expected_pipeline_configuration = {
             'some-pipeline': {
                 'consumers': [
-                    {'processor': 'A',
+                    {'__processor__': 'A',
                      'consumers': [
-                            {'processor': 'D'},
-                            {'processor': 'B',
+                            {'__processor__': 'D'},
+                            {'__processor__': 'B',
                              'consumers': [
-                                    {'processor': 'E',
-                                     'consumers': [{'processor':'F'}]},
+                                    {'__processor__': 'E',
+                                     'consumers': [{'__processor__':'F'}]},
                                     ]
                             },
                         ]
                      },
-                    {'processor': 'C'},
+                    {'__processor__': 'C'},
                 ]
             }
         }
@@ -1035,16 +1035,16 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'a-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'reverse'},
+                    {'__processor__': 'reverse'},
                 ],
                 'consumers': [
-                    {'processor': 'uppercase'},
+                    {'__processor__': 'uppercase'},
                 ],
                 'chained_error_consumers': [
-                    {'processor': 'reverse'},
+                    {'__processor__': 'reverse'},
                 ],
                 'error_consumers': [
-                    {'processor': 'uppercase'},
+                    {'__processor__': 'uppercase'},
                 ]
             }
         }
@@ -1055,17 +1055,17 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
             'a-pipeline': {
                 'consumers': [
                     {
-                        'processor': 'reverse',
+                        '__processor__': 'reverse',
                         'error_consumers': [
-                            {'processor': 'reverse'},
-                            {'processor': 'uppercase'},
+                            {'__processor__': 'reverse'},
+                            {'__processor__': 'uppercase'},
                         ]
                     },
                     {
-                        'processor': 'uppercase',
+                        '__processor__': 'uppercase',
                         'error_consumers': [
-                            {'processor': 'reverse'},
-                            {'processor': 'uppercase'},
+                            {'__processor__': 'reverse'},
+                            {'__processor__': 'uppercase'},
                         ]
                     },
                 ],
@@ -1078,8 +1078,8 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'uppercase'},
-                    {'processor': 'reverse'},
+                    {'__processor__': 'uppercase'},
+                    {'__processor__': 'reverse'},
                 ]
             },
             'alias': {
@@ -1092,15 +1092,15 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         expected_pipeline_configuration = {
             'only-pipeline': {
                 'consumers': [
-                    {'processor': 'uppercase',
-                     'consumers': [{'processor': 'reverse'}],
+                    {'__processor__': 'uppercase',
+                     'consumers': [{'__processor__': 'reverse'}],
                     }
                 ]
             },
             'alias': {
                 'consumers': [
-                    {'processor': 'uppercase',
-                     'consumers': [{'processor': 'reverse'}],
+                    {'__processor__': 'uppercase',
+                     'consumers': [{'__processor__': 'reverse'}],
                     }
                 ]
             },
@@ -1113,8 +1113,8 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'uppercase'},
-                    {'processor': 'i-do-not-exist'},
+                    {'__processor__': 'uppercase'},
+                    {'__processor__': 'i-do-not-exist'},
                 ]
             }
         }
@@ -1138,7 +1138,7 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'must-have-foo', 'notfoo': 'though'}, # but it won't get it
+                    {'__processor__': 'must-have-foo', 'notfoo': 'though'}, # but it won't get it
                 ]
             }
         }
@@ -1164,7 +1164,7 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'must-have-foo', 'foo': 'GOT IT', 'bar': 'nooo'},
+                    {'__processor__': 'must-have-foo', 'foo': 'GOT IT', 'bar': 'nooo'},
                 ]
             }
         }
@@ -1180,16 +1180,16 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'base-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'uppercase',
+                    {'__processor__': 'uppercase',
                      'option': 'to-override',
                      'this-option': 'will be gone'},
-                    {'processor': 'reverse'},
+                    {'__processor__': 'reverse'},
                 ]
             },
             'inheriting-pipeline': {
                 'inherits': 'base-pipeline',
                 'overrides': [
-                    {'processor': 'uppercase',
+                    {'__processor__': 'uppercase',
                      'option': 'now overridden'}
                 ]
             }
@@ -1198,19 +1198,19 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         expected_pipeline_configuration = {
             'base-pipeline': {
                 'consumers': [
-                    {'processor': 'uppercase',
+                    {'__processor__': 'uppercase',
                      'option': 'to-override',
                      'this-option': 'will be gone',
-                     'consumers': [{'processor': 'reverse'}],
+                     'consumers': [{'__processor__': 'reverse'}],
                     }
                 ]
             },
             'inheriting-pipeline': {
                 'inherits': 'base-pipeline',
                 'consumers': [
-                    {'processor': 'uppercase',
+                    {'__processor__': 'uppercase',
                      'option': 'now overridden',
-                     'consumers': [{'processor': 'reverse'}],
+                     'consumers': [{'__processor__': 'reverse'}],
                     }
                 ]
             },
@@ -1221,11 +1221,11 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
     def test_inheriting_fails_with_deep_nesting(self):
         pipeline_configuration = {
             'a': {
-                'chained_consumers': [{'processor': 'uppercase'}]
+                'chained_consumers': [{'__processor__': 'uppercase'}]
             },
             'b': {
                 'inherits': 'a',
-                'overrides': [{'processor': 'uppercase', 'foo': 'bar'}]
+                'overrides': [{'__processor__': 'uppercase', 'foo': 'bar'}]
             },
             'c': {
                 'inherits': 'b',
@@ -1238,11 +1238,11 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
     def test_inheriting_bogus_pipeline(self):
         pipeline_configuration = {
             'a': {
-                'chained_consumers': [{'processor': 'uppercase'}]
+                'chained_consumers': [{'__processor__': 'uppercase'}]
             },
             'b': {
                 'inherits': 'not a',
-                'overrides': [{'processor': 'uppercase', 'foo': 'bar'}]
+                'overrides': [{'__processor__': 'uppercase', 'foo': 'bar'}]
             },
         }
 
@@ -1251,11 +1251,11 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
     def test_not_all_overrides_used(self):
         pipeline_configuration = {
             'a': {
-                'chained_consumers': [{'processor': 'uppercase'}]
+                'chained_consumers': [{'__processor__': 'uppercase'}]
             },
             'b': {
                 'inherits': 'a',
-                'overrides': [{'processor': 'uppercase', 'foo': 'bar'}, {'processor': 'reverse', 'bar': 'baz'}],
+                'overrides': [{'__processor__': 'uppercase', 'foo': 'bar'}, {'__processor__': 'reverse', 'bar': 'baz'}],
             },
         }
         self.assertRaises(exceptions.ConfigurationError, self.get_processor_graph_factory, pipeline_configuration)
@@ -1268,16 +1268,16 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'some-pipeline': {
                 'consumers': [
-                    {'processor': 'C'},
+                    {'__processor__': 'C'},
                 ],
                 'chained_consumers': [
-                    {'processor': 'A',
-                     'consumers': [{'processor':'D'}]
+                    {'__processor__': 'A',
+                     'consumers': [{'__processor__':'D'}]
                     },
-                    {'processor': 'C',
+                    {'__processor__': 'C',
                      'chained_consumers': [
-                            {'processor': 'E'},
-                            {'processor': 'F'},
+                            {'__processor__': 'E'},
+                            {'__processor__': 'F'},
                         ]
                     },
                 ]
@@ -1285,9 +1285,9 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
             'other-pipeline': {
                 'inherits': 'some-pipeline',
                 'overrides': [
-                    {'processor': 'C', 'other_option': 'this processor should have E as a consumer'},
-                    {'processor': 'F', 'foo': 'bar'},
-                    {'processor': 'C', 'some_option': 'this processor should not have consumers'},
+                    {'__processor__': 'C', 'other_option': 'this processor should have E as a consumer'},
+                    {'__processor__': 'F', 'foo': 'bar'},
+                    {'__processor__': 'C', 'some_option': 'this processor should not have consumers'},
                 ]
             }
         }
@@ -1295,26 +1295,26 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         expected_pipeline_configuration = {
             'other-pipeline': {
                 'consumers': [
-                    {'consumers': [{'processor': 'D'},
-                                   {'consumers': [{'consumers': [{'foo': 'bar', 'processor': 'F'}],
-                                                   'processor': 'E'}],
+                    {'consumers': [{'__processor__': 'D'},
+                                   {'consumers': [{'consumers': [{'foo': 'bar', '__processor__': 'F'}],
+                                                   '__processor__': 'E'}],
                                     'other_option': 'this processor should have E as a consumer',
-                                    'processor': 'C'}],
-                     'processor': 'A'},
-                    {'processor': 'C', 'some_option': 'this processor should not have consumers'},
+                                    '__processor__': 'C'}],
+                     '__processor__': 'A'},
+                    {'__processor__': 'C', 'some_option': 'this processor should not have consumers'},
                 ],
                 'inherits': 'some-pipeline'
             },
             'some-pipeline': {
                 'consumers': [
                     {'consumers': [
-                            {'processor': 'D'},
+                            {'__processor__': 'D'},
                             {'consumers': [
-                                    {'consumers': [{'processor': 'F'}],
-                                     'processor': 'E'}],
-                             'processor': 'C'}],
-                     'processor': 'A'},
-                    {'processor': 'C'},
+                                    {'consumers': [{'__processor__': 'F'}],
+                                     '__processor__': 'E'}],
+                             '__processor__': 'C'}],
+                     '__processor__': 'A'},
+                    {'__processor__': 'C'},
                 ]
             }
         }
@@ -1325,7 +1325,7 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
         pipeline_configuration = {
             'base-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'uppercase'}
+                    {'__processor__': 'uppercase'}
                 ]
             },
             'inheriting-pipeline': {
@@ -1341,9 +1341,9 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
             my_pipeline=dict(
                 consumers=[
                     dict(
-                        processor='uppercase',
+                        __processor__='uppercase',
                         consumers=[
-                            dict(processor='lowercase')
+                            dict(__processor__='lowercase')
                         ]
                     )
                 ]
@@ -1408,10 +1408,10 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
             my_pipeline=dict(
                 consumers=[
                     dict(
-                        processor='uppercase',
+                        __processor__='uppercase',
                         uppercaser='UPPERCASER',
                         consumers=[
-                            dict(processor='lowercase', lowercaser='LOWERCASER')
+                            dict(__processor__='lowercase', lowercaser='LOWERCASER')
                         ]
                     )
                 ]
@@ -1435,10 +1435,10 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
             'namespace1.namespace2.my_pipeline':dict(
                 consumers=[
                     dict(
-                        processor='uppercase',
+                        __processor__='uppercase',
                         uppercaser='UPPERCASER',
                         consumers=[
-                            dict(processor='lowercase', lowercaser='LOWERCASER')
+                            dict(__processor__='lowercase', lowercaser='LOWERCASER')
                         ]
                     )
                 ]
@@ -1459,21 +1459,21 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
 
     def test_namespaced_imports(self):
         expected_pipeline_configuration = {
-            'ns1.ns2.ns3.lower':dict(consumers=[{'processor':'lowercaser'}]),
-            'ns1.upper':dict(consumers=[{'processor':'uppercaser'}]),
-            'ns1.ns2.side':dict(consumers=[{'processor':'sidecaser'}]),
+            'ns1.ns2.ns3.lower':dict(consumers=[{'__processor__':'lowercaser'}]),
+            'ns1.upper':dict(consumers=[{'__processor__':'uppercaser'}]),
+            'ns1.ns2.side':dict(consumers=[{'__processor__':'sidecaser'}]),
             'ns1.ns2.my_pipeline':dict(
                 consumers=[
                     dict(
-                        processor='uppercaser',
+                        __processor__='uppercaser',
                         consumers=[
-                            dict(processor='lowercaser',
+                            dict(__processor__='lowercaser',
                                  consumers=[
-                                    dict(processor='sidecaser',
+                                    dict(__processor__='sidecaser',
                                          consumers=[
-                                            dict(processor='rootcaser',
+                                            dict(__processor__='rootcaser',
                                                 consumers=[
-                                                    dict(processor='rootcaser')
+                                                    dict(__processor__='rootcaser')
                                                 ]
                                             )
                                          ]
@@ -1484,7 +1484,7 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
                     )
                 ]
             ),
-            'root':dict(consumers=[{'processor':'rootcaser'}])
+            'root':dict(consumers=[{'__processor__':'rootcaser'}])
         }
 
         # create a pipeline that uses different imports:
@@ -1515,17 +1515,17 @@ class TestProcessorGraphFactory(ProcessorGraphTest):
             'namespace1.namespace2.my_pipeline':dict(
                 consumers=[
                     dict(
-                        processor='uppercase',
+                        __processor__='uppercase',
                         uppercaser='UPPERCASER',
                         consumers=[
-                            dict(processor='lowercase', lowercaser='LOWERCASER')
+                            dict(__processor__='lowercase', lowercaser='LOWERCASER')
                         ]
                     )
                 ]
             ),
             'namespace1.namespace2.included_pipeline':dict(
                 consumers=[
-                    dict(processor='lowercase', lowercaser='LOWERCASER')
+                    dict(__processor__='lowercase', lowercaser='LOWERCASER')
                 ]
             )
         }
@@ -1606,10 +1606,10 @@ class TestMisconfigurationHinting(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'foo-provider'},
-                    {'processor': 'bar-provider'},
-                    {'processor': 'bar-consumer'},
-                    {'processor': 'foo-consumer'},
+                    {'__processor__': 'foo-provider'},
+                    {'__processor__': 'bar-provider'},
+                    {'__processor__': 'bar-consumer'},
+                    {'__processor__': 'foo-consumer'},
                 ]
             }
         }
@@ -1624,10 +1624,10 @@ class TestMisconfigurationHinting(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'foo-consumer'},
-                    {'processor': 'foo-provider'},
-                    {'processor': 'bar-provider'},
-                    {'processor': 'bar-consumer'},
+                    {'__processor__': 'foo-consumer'},
+                    {'__processor__': 'foo-provider'},
+                    {'__processor__': 'bar-provider'},
+                    {'__processor__': 'bar-consumer'},
                 ]
             }
         }
@@ -1649,10 +1649,10 @@ class TestMisconfigurationHinting(ProcessorGraphTest):
         pipeline_configuration = {
             'only-pipeline': {
                 'chained_consumers': [
-                    {'processor': 'foo-consumer'},
-                    {'processor': 'bar-consumer'},
-                    {'processor': 'foo-provider'},
-                    {'processor': 'bar-provider'},
+                    {'__processor__': 'foo-consumer'},
+                    {'__processor__': 'bar-consumer'},
+                    {'__processor__': 'foo-provider'},
+                    {'__processor__': 'bar-provider'},
                 ]
             }
         }
@@ -1680,13 +1680,13 @@ class TestMisconfigurationHinting(ProcessorGraphTest):
             'only-pipeline': {
                 'consumers': [
                     {
-                        'processor': 'foo-consumer2',
+                        '__processor__': 'foo-consumer2',
                         'consumers': [
-                            {'processor': 'foo-consumer', 'id': 'reuse_me'},
+                            {'__processor__': 'foo-consumer', 'id': 'reuse_me'},
                         ]
                     },
                     {
-                        'processor': 'foo-provider',
+                        '__processor__': 'foo-provider',
                         'consumers': [{'existing': 'reuse_me'}]
                     }
                 ]
@@ -1724,21 +1724,21 @@ class TestConditional(ProcessorGraphTest):
             'only-pipeline': {
                 'consumers': [
                     {
-                        'processor': 'lambda-decider',
+                        '__processor__': 'lambda-decider',
                         'lambda': 'input, map=["upper", "lower"]: map.index(input.lower())',
                         'consumers': [
                             {
-                                'processor': 'uppercase',
+                                '__processor__': 'uppercase',
                                 'consumers': [{'existing': 'exit'}]
                             },
                             {
-                                'processor': 'lowercase',
+                                '__processor__': 'lowercase',
                                 'consumers': [{'existing': 'exit'}]
                             },
                         ]
                     },
                     {
-                        'processor': 'reverse',
+                        '__processor__': 'reverse',
                         'id': 'exit'
                     },
                 ]


### PR DESCRIPTION
From CHANGES.txt:

Features:

```
- Built-in and contrib providers now use "processor: ..." instead
    of "pipeline: ...", and are able to depend on arbitrary dependencies.
    The dependencies are invoked with the baton as the first and
    only argument.

    This makes it easier for one provider to call a function on another
    provider.
```

Internal changes:
    - piped.processing now uses stores the processor name under the
        '**processor**' key instead of 'processor', enabling processors to
        take 'processor' as a keyword argument.

Backward-incompatible changes:
    - The syntax for creating processors in the YAML configuration has changed.
        Using "processor: processor_name" is no longer supported. Use

```
        - processor_name

        OR

        - procsesor_name:
            foo: bar

        OR

        - __processor__: processor_name
          foo: bar

     instead.
```
