### PR TITLE
Piped debug and tracing

### DIFF
--- a/piped/processing.py
+++ b/piped/processing.py
@@ -496,9 +496,13 @@ class TwistedProcessorGraphEvaluator(object):
     def traced_process(self, *a, **kw):
         """ Traces and processes a baton asynchronously through a processor graph.
 
+        .. warn:: The act of tracing introduces a new variable in the locals of
+            all the traced frames on the form ``trace_token_UUID4``.
+
         .. seealso:: :class:`_ProcessTracer` and :meth:`process`.
         """
         tracer = _ProcessTracer()
+        # add the token to the current locals, so _refresh_trace_token may find it
         locals()[tracer.token_name] = tracer.token_value
 
         try:

--- a/piped/util.py
+++ b/piped/util.py
@@ -571,7 +571,11 @@ class PullFromQueueAndProcessWithDependency(service.Service):
                 self._waiting_on_processor = None
 
 
-class NonCleaningFailure(failure.Failure):
+# we store a reference to the superclass of NonCleaningFailure here because it may change
+# due to the monkey-patching performed when piped is started with the -D argument
+NonCleaningFailureSuperClass = failure.Failure
+
+class NonCleaningFailure(NonCleaningFailureSuperClass):
     """ A Failure subclass that doesn't replace its traceback with repr'd objects. """
 
     def __init__(self, *a, **kw):
@@ -581,7 +585,7 @@ class NonCleaningFailure(failure.Failure):
         if (twisted.version.major, twisted.version.minor) > (11, 0):
             kw.setdefault('captureVars', True)
 
-        failure.Failure.__init__(self, *a, **kw)
+        NonCleaningFailureSuperClass.__init__(self, *a, **kw)
 
     def cleanFailure(self):
         pass


### PR DESCRIPTION
Fixes piped -D and enabled tracing to work even when a processor disrupts the current stack during its processing by setting the trace token to the locals of intermediary frames as they are discovered by the tracer.

This slightly pollutes the namespace of affected functions, but works in a lot more cases. 
