### PR TITLE
cyclone support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,11 @@ Features:
       and processing them in pipelines, as well as a simple helper
       for creating and providing AMQP-based RPC-clients.
 
+    - Cyclone: Support for Cyclone applications (http://cyclone.io), which
+      is an implementation of Tornado (http://tornadoweb.org) on top of
+      Twisted. This enables building full-fledged web-apps that use the
+      dependency/resource management/pipelines in piped.
+
     - Built-in and contrib providers now use "processor: ..." instead
         of "pipeline: ...", and are able to depend on arbitrary dependencies.
         The dependencies are invoked with the baton as the first and

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,8 @@
-Piped: a pipeline processing framework
-======================================
+Piped: a framework and application server with pipelines
+========================================================
 
-Piped is an `MIT-licensed <https://github.com/foundit/Piped/blob/develop/LICENSE>`_ framework for
+Piped is an `MIT-licensed <https://github.com/foundit/Piped/blob/develop/LICENSE>`_ framework and
+application server with built-in support for
 `flow based programming <http://en.wikipedia.org/wiki/Flow-based_programming>`_ written in Python that focuses on:
 
 * Extendability.
@@ -22,10 +23,10 @@ The documentation is available at http://piped.io.
 Protocols and Extensions
 ------------------------
 
-* HTTP with `twisted.web <http://twistedmatrix.com/trac/wiki/TwistedWeb>`_
+* HTTP/HTTPS with `twisted.web <http://twistedmatrix.com/trac/wiki/TwistedWeb>`_ or `Cyclone <http://cyclone.io>`_ (based on `Tornado <http://tornadoweb.org>`).
 * SMTP with `twisted.mail <http://twistedmatrix.com/trac/wiki/TwistedMail>`_
 * SSH with `twisted.conch <http://twistedmatrix.com/trac/wiki/TwistedConch>`_
-* `ZeroMQ <http://www.zeromq.org/>`_ and `AMQP <http://www.amqp.org/>`_ (especially `RabbitMQ <http://www.rabbitmq.com/>`_)
+* `ZeroMQ <http://www.zeromq.org/>`_ and `AMQP <http://www.amqp.org/>`_ (i.e `RabbitMQ <http://www.rabbitmq.com/>`_)
 * `ZooKeeper <http://zookeeper.apache.org/>`_
 * Database-connectivity (with `SQLAlchemy <http://sqlalchemy.org>`_)
 * Data-validation (with `FormEncode <http://www.formencode.org/>`_)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -16,6 +16,7 @@ eggs = ${buildout:eggs}
 [piped-plugins]
 develop =
     contrib/amqp
+    contrib/cyclone
     contrib/database
     contrib/manhole
     contrib/status_testing
@@ -30,3 +31,4 @@ eggs =
     piped_validation
     piped_zmq
     piped_zookeeper
+    piped_cyclone

--- a/contrib/cyclone/LICENSE
+++ b/contrib/cyclone/LICENSE
@@ -1,0 +1,19 @@
+This is the MIT license: http://www.opensource.org/licenses/mit-license.php
+
+Copyright (c) 2012, Found IT A/S and Piped Project Contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
+to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/contrib/cyclone/piped/plugins/cyclone_provider.py
+++ b/contrib/cyclone/piped/plugins/cyclone_provider.py
@@ -1,0 +1,1 @@
+from piped_cyclone.providers import *

--- a/contrib/cyclone/piped/plugins/cyclone_provider.py
+++ b/contrib/cyclone/piped/plugins/cyclone_provider.py
@@ -1,1 +1,2 @@
+from piped_cyclone import version
 from piped_cyclone.providers import *

--- a/contrib/cyclone/piped_cyclone/__init__.py
+++ b/contrib/cyclone/piped_cyclone/__init__.py
@@ -1,0 +1,3 @@
+# See http://www.python.org/dev/peps/pep-0386/ for version numbering, especially NormalizedVersion
+from distutils import version
+version = version.LooseVersion('0.2.0')

--- a/contrib/cyclone/piped_cyclone/handlers.py
+++ b/contrib/cyclone/piped_cyclone/handlers.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2012, Found IT A/S and Piped Project Contributors.
+# See LICENSE for details.
 import os
 import json
 

--- a/contrib/cyclone/piped_cyclone/handlers.py
+++ b/contrib/cyclone/piped_cyclone/handlers.py
@@ -1,0 +1,172 @@
+import os
+import json
+
+from cyclone import web
+from zope import interface
+from twisted.internet import defer, reactor
+from twisted.web import util
+from twisted.python import failure
+
+from piped import debugger, log
+
+
+class DebuggableHandler(web.RequestHandler):
+    """ A request handler that lets allowed users view full tracebacks and execute
+    code interactively to inspect the traceback frames.
+
+    Subclasses must make sure that :meth:`.prepare()` is called. If you want to require login
+    in addition to the built-in ip-based checks, subclass this class and override
+    :meth:`~DebuggableHandler.post_debug` and :meth:`~DebuggableHandler.get_debug`::
+
+        class AuthingDebuggableHandler(web.RequestHandler):
+            @web.authenticated
+            def post_debug(self, *a, **kw):
+                super(AuthingDebuggableHandler, self).post_debug(*a, **kw)
+
+            @web.authenticated
+            def get_debug(self, *a, **kw):
+                super(AuthingDebuggableHandler, self).get_debug(*a, **kw)
+    """
+    _debugging_failures = dict()
+    _debugging_timeouts = dict()
+
+    def prepare(self):
+        """ Override this request handlers methods if the user tries to access a debugger. """
+        if self.settings.get('debug', False) and self.get_argument('__debug__', None):
+            self.post = self.post_debug
+            self.get = self.get_debug
+
+    def post_debug(self, *a, **kw):
+        """ Executes an expression within a debugger frame. """
+        debugger = self.get_debugger(self.get_argument('__debug__', None), timeout=self.settings.get('debug_timeout', 60))
+        if not debugger:
+            raise web.HTTPError(404, 'No such debugger.')
+
+        allowed = self.settings.get('debug_allow', list())
+
+        if not self.request.remote_ip in allowed:
+            raise web.HTTPError(403)
+
+        expr = self.get_argument('expr', None)
+        frame_no = self.get_argument('frame_no', None)
+
+        result = debugger.exec_expr(expr, int(frame_no))
+        self.finish(json.dumps(result))
+
+    def get_debug(self, *a, **kw):
+        """ Returns a HTML-page that serves as a front-end to the debugger. """
+        debugger = self.get_debugger(self.get_argument('__debug__', None), timeout=self.settings.get('debug_timeout', 60))
+
+        if not debugger or not self.request.remote_ip in self.settings.get('debug_allow', list()):
+            raise web.HTTPError(404, 'No such debugger.')
+
+        self.finish(self._get_debug_html(debugger.failure))
+
+    def write_error(self, status_code, **kwargs):
+        if not self.settings.get('debug', False):
+            super(DebuggableHandler, self).write_error(status_code, **kwargs)
+            return
+
+        # store the current failure reason
+        reason = None
+
+        if 'exception' in kwargs and isinstance(kwargs['exception'], failure.Failure):
+            reason = kwargs['exception']
+
+        if 'exc_info' in kwargs:
+            try:
+                raise exc_info[0], exc_info[1], exc_info[2]
+            except Exception as e:
+                reason = failure.Failure()
+
+        if reason:
+            self.register_failure(reason, timeout=self.settings.get('debug_timeout', 60))
+
+            ajax_endpoint = self.request.path + '?__debug__='+str(id(reason))
+            full_url_to_debugger = self.request.protocol + '://' + self.request.host + ajax_endpoint
+
+            log.error('Debugger for [{0}] started at [{1}]'.format(reason.getErrorMessage(), full_url_to_debugger))
+
+            self.request.arguments['__debug__'] = [str(id(reason))]
+            if self.request.remote_ip in self.settings.get('debug_allow', list()):
+                return self.get_debug()
+
+        super(DebuggableHandler, self).write_error(status_code, **kwargs)
+
+    def _get_debug_html(self, reason):
+        traceback_as_html = util.formatFailure(reason)
+        ajax_endpoint = self.request.path + '?__debug__='+str(id(reason))
+
+        here = os.path.abspath(os.path.dirname(__file__))
+
+        template_name = self.settings.get('debug_template', os.path.join(here, 'templates', 'debugger.html'))
+
+        try:
+            return self.render_string(template_name, traceback_as_html=traceback_as_html, ajax_endpoint=ajax_endpoint)
+        except Exception as e:
+            log.error()
+            raise e
+
+    @classmethod
+    def register_failure(cls, reason, timeout):
+        key = str(id(reason))
+        cls._debugging_failures[key] = debugger.Debugger(reason)
+
+        cls._debugging_timeouts[key] = reactor.callLater(timeout, cls._timeout_debugger, key)
+
+    @classmethod
+    def get_debugger(cls, id, timeout):
+        debugger = cls._debugging_failures.get(id, None)
+        delayed_call = cls._debugging_timeouts.pop(id, None)
+
+        if delayed_call:
+            delayed_call.cancel()
+            cls._debugging_timeouts.pop(id, None)
+            cls._debugging_timeouts[id] = reactor.callLater(timeout, cls._timeout_debugger, id)
+
+        return debugger
+
+    @classmethod
+    def _timeout_debugger(cls, id):
+        cls._debugging_failures.pop(id, None)
+        cls._debugging_timeouts.pop(id, None)
+
+
+class PipedRequestHandlerProxy(object):
+    """ A simple proxy that uses a dependency to process web requests.
+
+    Assumes the provided resource acts like a :class:`cyclone.web.RequestHandler`.
+    """
+
+    def __init__(self, dependency):
+        self.dependency = dependency
+
+    def __call__(self, *args, **kwargs):
+        self.handler_args = args
+        self.handler_kwargs = kwargs
+        return self
+
+    @defer.inlineCallbacks
+    def _execute(self, *a, **kw):
+        handler_class = yield self.dependency.wait_for_resource()
+        handler = handler_class(*self.handler_args, **self.handler_kwargs)
+        yield handler._execute(*a, **kw)
+
+
+class PipelineRequestHandler(DebuggableHandler):
+    """ Request handler for requests that will be served through pipelines. """
+
+    def __init__(self, *args, **kwargs):
+        super(PipelineRequestHandler, self).__init__(*args, **kwargs)
+
+        for method in self.SUPPORTED_METHODS:
+            setattr(self, method.lower(), self.handle)
+
+    def initialize(self, dependency=None):
+        self.dependency = dependency
+
+    @web.asynchronous
+    @defer.inlineCallbacks
+    def handle(self, *args, **kwargs):
+        pipeline = yield self.dependency.wait_for_resource()
+        pipeline(dict(handler=self, args=args, kwargs=kwargs))

--- a/contrib/cyclone/piped_cyclone/providers.py
+++ b/contrib/cyclone/piped_cyclone/providers.py
@@ -10,6 +10,9 @@ from piped_cyclone import handlers
 class CycloneProvider(object):
     """ Provides support for running `Cyclone <http://cyclone.io>`_ applications within Piped.
 
+    For more in-depth documentation about Cyclone see: `Cyclone on GitHub <http://github.com/fiorix/cyclone>`_,
+    and the `Tornado documentation <http://www.tornadoweb.org/documentation/index.html>`_.
+
     Configuration example:
 
     .. code-block:: yaml

--- a/contrib/cyclone/piped_cyclone/providers.py
+++ b/contrib/cyclone/piped_cyclone/providers.py
@@ -1,0 +1,189 @@
+from cyclone import web
+from zope import interface
+from twisted.application import strports
+from twisted.python import reflect, filepath
+
+from piped import resource
+from piped_cyclone import handlers
+
+
+class CycloneProvider(object):
+    """ Provides support for running `Cyclone <http://cyclone.io>`_ applications within Piped.
+
+    Configuration example:
+
+    .. code-block:: yaml
+
+        cyclone:
+            site_name:
+                listen: 8888
+                type: cyclone.web.Application # or a fully qualified name of a subclass
+                application:
+                    handlers:
+                        # a tuple: pattern, handler, kwargs (optional), name (optional)
+                        - ['/pattern', name.of.RequestHandler]
+                        # a dict
+                        - pattern: /another/(?P<pattern>.*)
+                          handler: name.of.RequestHandler
+                          name: handler_name # optional
+                          kwargs: # optional
+                            foo: 123
+
+                    debug: true # see the debugging section below.
+                    debug_allow: # optional list of ip addresses that are allowed to see tracebacks and the interactive debugger.
+                        - 127.0.0.1
+                    debug_timeout: 60 # (default), time in seconds to keep debuggers resident in memory before garbage collecting them.
+                    debug_template: debugger.html  # name of the debugger template to use. if not set, uses the built-in template.
+
+    The ``listen`` parameter is a Twisted ``strport``, which can be used to declare which interfaces the server should be listening on, SSL
+    parameters and more. For more information, see `strports in the Twisted documentation
+    <http://twistedmatrix.com/documents/11.0.0/api/twisted.internet.endpoints.html#serverFromString>`_.
+
+    Each ``handler`` may be one of the following:
+
+        * Fully qualified class name of a RequestHandler instance. The class will be invoked with
+          cls.configure(runtime_environment) once if the method is defined. This allows for the
+          class to perform any necessary setup / bootstrapping into the runtime_environment.
+
+        * A dict with a ``class`` key set: Same as the above.
+
+        * A dict with the ``provider`` key set. The provider is assumed to provide a subclass of
+          RequestHandler as the resource.
+
+          If the provider starts with ``pipeline.``, the provided resource will not be used as
+          a RequestHandler, but will be called with ``resource.__call__(baton)``. The baton contains
+          the following keys:
+
+            * handler: A RequestHandler that is handling the request.
+            * args: A tuple of arguments from the url pattern
+            * kwargs: A dict of keyword arguments from the url pattern
+
+          The pipeline should take care of calling ``baton['handler'].finish()`` when the request is
+          finished.
+
+    If the application setting ``ui_modules`` is a string, it will be loaded to a python object via
+    :meth:`twisted.python.reflect.namedAny`. If it is a dict, all values are assumed to be strings
+    that are fully qualified name of :class:`cyclone.web.UIModule` classes.
+
+    Application settings that end with ``_path`` and are :class:`twisted.python.filepath.FilePath` instances
+    will be converted to absolute paths. This enables the use of the :ref:`\!path <path-constructor>`-constructor
+    in the configuration files.
+
+    Global dependencies can be added to the application settings under the ``piped_dependencies`` key, which
+    should be a dict. This dict will be converted to a :class:`~piped.dependencies.DependencyMap` before being
+    given to the :class:`cyclone.web.Application` instance as a setting.
+
+    In order to enable debugging tracebacks from the web server, configure the cyclone application as in the example
+    configuration above and make sure your request handlers subclasses :class:`piped_cyclone.handlers.DebuggableHandler`.
+
+    .. warning:: Enabling debugging enables allowed clients to execute arbitrary code within the Piped process.
+
+    To make stack traces keep their frame information, use :option:`piped -D <piped -D>` when launching :program:`piped`.
+
+    """
+    interface.classProvides(resource.IResourceProvider)
+
+    configuration_key = 'cyclone'
+
+    def __init__(self):
+        self._configured_handler_factory_ids = set()
+        self._applications_by_name = dict()
+
+    def configure(self, runtime_environment):
+        self.runtime_environment = runtime_environment
+        self.dependency_manager = runtime_environment.dependency_manager
+        self.resource_manager = runtime_environment.resource_manager
+
+        cm = runtime_environment.configuration_manager
+
+        for name, config in cm.get(self.configuration_key, dict()).items():
+            listen = str(config.pop('listen', '8888'))
+            application_factory_type = config.pop('type', 'cyclone.web.Application')
+            application_factory = reflect.namedAny(application_factory_type)
+
+            application_config = config.pop('application', dict())
+
+            handlers = application_config.pop('handlers', [])
+
+            transforms = self._resolve_transforms(application_config.pop('transforms', list()))
+
+            if 'ui_modules' in application_config:
+                ui_modules = application_config['ui_modules']
+                if isinstance(ui_modules, dict):
+                    for key, value in ui_modules.items():
+                        ui_modules[key] = reflect.namedAny(value)
+                elif isinstance(ui_modules, basestring):
+                    application_config['ui_modules'] = reflect.namedAny(ui_modules)
+                else:
+                    raise Exception('Unknown ui_modules type: {0}'.format(type(ui_modules)))
+
+            for key, value in application_config.items():
+                if key.endswith('_path') and isinstance(value, filepath.FilePath):
+                    application_config[key] = value.path
+
+            for i, handler in enumerate(handlers):
+                handlers[i] = self._resolve_urlspec(handler)
+
+            if 'piped_dependencies' in application_config:
+                for key, value in application_config['piped_dependencies'].items():
+                    application_config['piped_dependencies'][key] = dict(provider=value) if isinstance(value, basestring) else value
+                application_config['piped_dependencies'] = self.dependency_manager.create_dependency_map(self, **application_config['piped_dependencies'])
+
+            application = application_factory(handlers, transforms=transforms, **application_config)
+
+            service = strports.service(listen, application)
+            service.setServiceParent(runtime_environment.application)
+
+            self._applications_by_name[name] = application
+
+            self.resource_manager.register('cyclone.application.{0}'.format(name), provider=self)
+
+    def add_consumer(self, resource_dependency):
+        name = resource_dependency.provider.rsplit('.', 1)[-1]
+        application = self._applications_by_name[name]
+        resource_dependency.on_resource_ready(application)
+
+    def _resolve_urlspec(self, url_spec):
+        if isinstance(url_spec, (list, tuple)):
+            url_spec = dict(zip(['pattern', 'handler_class', 'kwargs', 'name'], url_spec))
+
+        # string -> class specification
+        if isinstance(url_spec['handler_class'], basestring):
+            url_spec['handler_class'] = {'class':url_spec['handler_class']}
+
+        if 'provider' in url_spec['handler_class']:
+            provider = url_spec['handler_class']['provider']
+            dependency = self.dependency_manager.add_dependency(self, url_spec['handler_class'])
+            url_spec.setdefault('kwargs', dict()).update(dependency=dependency)
+
+            if provider.startswith('pipeline.'):
+                url_spec['handler_class'] = handlers.PipelineRequestHandler
+                return web.url(**url_spec)
+
+            url_spec['handler_class'] = handlers.PipedRequestHandlerProxy(dependency)
+            return web.url(**url_spec)
+
+        if 'class' in url_spec['handler_class']:
+            cls = reflect.namedAny(url_spec['handler_class']['class'])
+            if id(cls) not in self._configured_handler_factory_ids:
+                self._configured_handler_factory_ids.add(id(cls))
+
+                try:
+                    cls.configure(self.runtime_environment)
+                except AttributeError as ae:
+                    if "has no attribute 'configure'" not in ae.args[0]:
+                        raise
+
+            url_spec['handler_class'] = cls
+            return web.url(**url_spec)
+
+        raise Exception('unknown provider...')
+
+    def _resolve_transforms(self, transforms):
+        if not transforms:
+            return None
+
+        for i, transform in transforms:
+            transforms[i] = reflect.namedAny(transform)
+
+        return transforms

--- a/contrib/cyclone/piped_cyclone/providers.py
+++ b/contrib/cyclone/piped_cyclone/providers.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2012, Found IT A/S and Piped Project Contributors.
+# See LICENSE for details.
 from cyclone import web
 from zope import interface
 from twisted.application import strports

--- a/contrib/cyclone/piped_cyclone/templates/debugger.html
+++ b/contrib/cyclone/piped_cyclone/templates/debugger.html
@@ -1,0 +1,100 @@
+<html>
+    <head>
+        <title>web.Application Traceback (most recent call last)</title>
+            <script type="text/javascript" src="{% block jquery_url %}https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js{% end %}"></script>
+            <script type="text/javascript">
+$(document).ready(function() {
+    var ajax_endpoint = "{{ ajax_endpoint }}";
+
+    $('.frame,.firstFrame').each(function(i, item) {
+        // Make the location div clickable
+        var location = $(item).find('.location');
+        location.click(function() {
+            location.siblings().toggle();
+            $(item).find('input').focus();
+        });
+        location.css('cursor', 'pointer');
+
+        // create the buffer and input divs
+        var buffer = $('<div class="buffer"></div>');
+        var input = $('<input class="expr monospaced"/>');
+        var input_div = $('<div><span class="prompt monospaced">&#62;&#62;&#62;</span></div>');
+        input_div.css('width', location.width());
+        buffer.css('width', '100%%');
+
+        // variables for the command history
+        var cmd_history = [];
+        var cmd_current = 0;
+
+        input.bind('keydown', function(e) {
+            var key = e.keyCode || e.which;
+            if(key == 13 && input.val()) { // enter
+                var expr = input.val();
+
+                // update the command history
+                cmd_history.push(expr);
+                cmd_current = cmd_history.length;
+                input.val('');
+
+                // execute the expression in the debugger
+                $.ajax({
+                    url: ajax_endpoint,
+                    dataType: 'json',
+                    data: {
+                        frame_no: i,
+                        expr: expr
+                    },
+                    type: 'POST',
+                    success: function(data, textStatus, jqXHR) {
+                        buffer.append($('<div class="monospaced"/>').text('>>> '+expr));
+                        buffer.append($('<div class="monospaced"/>').text(data));
+                        // set the font-family of the new elements.
+                        buffer.find('.monospaced').css('font-family', 'monospace');
+                        input.focus();
+                    },
+                    error: function(jqXHR, textStatus, errorThrown) {
+                        var result_div = $('<div style="background: red"/>')
+                        if(jqXHR.status == 404) {
+                            result_div.text('Got a 404 when performing the ajax request. This either means the debugger \
+                                                was reaped due to inactivity on the server side, or that this page is \
+                                                trying to use the wrong endpoint. If the debugger was reaped, consider \
+                                                adjusting the inactive time.');
+                        } else {
+                            result_div.text('Unknown response from the server: '+jqXHR.status+': '+textStatus);
+                        }
+                        buffer.append(result_div);
+                    }
+                });
+            } else if (key == 38)  { // up arrow fetches the previous command from the history
+                cmd_current = Math.max(0, cmd_current-1);
+                input.val(cmd_history[cmd_current]);
+            } else if (key == 40) { // down arrow fetches the next command from the command history
+                cmd_current = Math.min(cmd_history.length, cmd_current+1);
+                if(cmd_current == cmd_history.length) {
+                    input.val('');
+                } else {
+                    input.val(cmd_history[cmd_current]);
+                }
+            }
+        });
+
+        // add our divs to the current stack frame
+        $(item).append(buffer);
+        input_div.append(input);
+        $(item).append(input_div);
+
+        // set the input width
+        input.css('width', input_div.width()-input_div.find('.prompt').width());
+
+        $(item).find('.monospaced').css('font-family', 'monospace');
+    });
+    $('.location').click(); // start with all the except the last hidden
+    $('.location:last').click();
+});
+        </script>
+    </head>
+    <body>
+        <div><b>web.Application Traceback (most recent call last): </b>(<a href="{{ ajax_endpoint }}">direct link to debugger</a>)</div>
+        <div>{% raw traceback_as_html %}</div>
+    </body>
+</html>

--- a/contrib/cyclone/piped_cyclone/test/test_cyclone.py
+++ b/contrib/cyclone/piped_cyclone/test/test_cyclone.py
@@ -1,0 +1,258 @@
+import re
+import socket
+
+from cyclone import web, httpclient
+from twisted.application import service
+from twisted.internet import defer
+from twisted.python import filepath, reflect, failure
+from twisted.trial import unittest
+from piped import processing, util
+from piped.dependencies import ResourceDependency
+
+from piped_cyclone import providers, handlers
+
+
+class TestHelloHandler(web.RequestHandler):
+    def get(self):
+        self.finish('get from test hello handler')
+
+
+class TestRaisingHandler(handlers.DebuggableHandler):
+    def get(self):
+        foo = 123
+        1/0
+
+class FooModule(web.UIModule):
+    pass
+
+
+class TestApplication(web.Application):
+    pass
+
+
+class CycloneProviderTest(unittest.TestCase):
+
+    def setUp(self):
+        self.runtime_environment = processing.RuntimeEnvironment()
+        self.service = service.IService(self.runtime_environment.application)
+        self.dependency_manager = self.runtime_environment.dependency_manager
+        self.configuration_manager = self.runtime_environment.configuration_manager
+        self.resource_manager = self.runtime_environment.resource_manager
+
+        self.dependency_manager.configure(self.runtime_environment)
+
+    def tearDown(self):
+        if self.service.running:
+            self.service.stopService()
+
+    def get_free_port(self):
+        sock = socket.socket()
+        sock.bind(('', 0))
+        free_port = sock.getsockname()[1]
+        sock.close()
+        return free_port
+
+    def get_configured_cyclone(self, name='test_cyclone', **config):
+        if 'listen' not in config:
+            config['listen'] = self.get_free_port()
+
+        resource_name = 'cyclone.application.{0}'.format(name)
+        self.configuration_manager.set('cyclone.{0}'.format(name), config)
+
+        provider = providers.CycloneProvider()
+        provider.configure(self.runtime_environment)
+
+        provider = self.resource_manager.get_provider_or_fail(resource_name)
+        dependency = ResourceDependency(provider=resource_name)
+        provider.add_consumer(dependency)
+
+        return dependency.get_resource()
+
+    @defer.inlineCallbacks
+    def test_simple(self):
+        port = self.get_free_port()
+        app = self.get_configured_cyclone(
+            listen = port,
+            application=dict(
+                handlers=[
+                    ('/', reflect.fullyQualifiedName(TestHelloHandler))
+                ],
+
+                templates_path = filepath.FilePath('.'),
+                static_path = filepath.FilePath('.'),
+
+                ui_modules = dict(
+                    foo = reflect.fullyQualifiedName(FooModule)
+                )
+            )
+        )
+        self.assertIsInstance(app, web.Application)
+
+
+        # the _paths in the setting should have been rewritten from FilePaths to strings
+        self.assertIsInstance(app.settings.templates_path, basestring)
+        self.assertIsInstance(app.settings.static_path, basestring)
+
+        # the foo module should be resolved to an instance
+        self.assertIdentical(app.settings.ui_modules['foo'], FooModule)
+
+        # start the web application
+        yield self.service.startService()
+
+        response = yield httpclient.fetch('http://localhost:{0}'.format(port))
+
+        self.assertEqual(response.body, 'get from test hello handler')
+        self.assertEqual(response.code, 200)
+
+    def test_custom_app(self):
+        app = self.get_configured_cyclone(
+            type = reflect.fullyQualifiedName(TestApplication)
+        )
+        self.assertIsInstance(app, TestApplication)
+
+    @defer.inlineCallbacks
+    def test_with_pipeline(self):
+        class Provider:
+            batons = list()
+
+            def add_consumer(self, resource_dependency):
+                resource_dependency.on_resource_ready(self)
+
+            def __call__(self, baton):
+                self.batons.append(baton)
+                baton['handler'].set_status(201)
+                baton['handler'].finish('hello from the pipeline')
+
+        provider = Provider()
+        self.resource_manager.register('pipeline.foo', provider)
+
+        port = self.get_free_port()
+        app = self.get_configured_cyclone(
+            listen = port,
+            application=dict(handlers=[
+                ('/pipeline/?(?P<rest>.*)', dict(provider='pipeline.foo'))
+            ])
+        )
+        self.dependency_manager.resolve_initial_states()
+
+        # start the web application
+        yield self.service.startService()
+
+        response = yield httpclient.fetch('http://localhost:{0}/pipeline/123'.format(port))
+
+        self.assertEqual(response.body, 'hello from the pipeline')
+        self.assertEqual(response.code, 201)
+
+        self.assertEqual(len(provider.batons), 1)
+        self.assertIsInstance(provider.batons[0]['handler'], handlers.PipelineRequestHandler)
+
+        self.assertEqual(provider.batons[0]['kwargs'], dict(rest=u'123'))
+
+    @defer.inlineCallbacks
+    def test_with_dependency(self):
+        class Provider(web.RequestHandler):
+            @classmethod
+            def add_consumer(cls, resource_dependency):
+                resource_dependency.on_resource_ready(cls)
+
+            def get(self):
+                self.set_status(202)
+                self.finish('hello from the foo provider')
+
+        self.resource_manager.register('a.dependency.foo', Provider)
+
+        port = self.get_free_port()
+        app = self.get_configured_cyclone(
+            listen = port,
+            application=dict(
+                handlers=[
+                    ('/dependency', dict(provider='a.dependency.foo'))
+                ],
+                piped_dependencies = dict(
+                    foo = 'a.dependency.foo'
+                )
+            )
+        )
+        self.dependency_manager.resolve_initial_states()
+
+        # assert that the piped_dependencies is available in the application settings
+        self.assertEqual(app.settings.piped_dependencies.foo, Provider)
+
+        # start the web application
+        yield self.service.startService()
+
+        response = yield httpclient.fetch('http://localhost:{0}/dependency'.format(port))
+
+        self.assertEqual(response.body, 'hello from the foo provider')
+        self.assertEqual(response.code, 202)
+
+    @defer.inlineCallbacks
+    def test_debugging(self):
+        port = self.get_free_port()
+        app = self.get_configured_cyclone(
+            listen = port,
+            application=dict(
+                handlers=[
+                    ('/', reflect.fullyQualifiedName(TestRaisingHandler))
+                ],
+                debug = True,
+                debug_allow = ['127.0.0.1'],
+                debug_timeout = 10
+            )
+        )
+
+        # start the web application
+        yield self.service.startService()
+
+        try:
+            # perform the web request with debugging enabled so we can inspect the stack :)
+            defer.setDebugging(True)
+
+            response = yield httpclient.fetch('http://localhost:{0}/'.format(port))
+        finally:
+            defer.setDebugging(False)
+
+        self.assertEqual(response.code, 500)
+        self.assertIn('web.Application Traceback (most recent call last)', response.body)
+        self.assertIn('exceptions.ZeroDivisionError', response.body)
+
+        debugger_id = re.compile(r'.*__debug__=(?P<id>.*)".*').search(response.body).groupdict()['id']
+
+        # in the context, "foo" has been repr'ed to a string by failure.Failure.cleanFailure(). this does not
+        # happen if piped -D is used, which replaces the failure class with a subclass that skips the cleaning.
+        #
+        # exec "foo + ''.join(reversed(foo))", which should return 123321 as a json-encoded string
+        exec_response = yield httpclient.fetch('http://localhost:{0}/?__debug__={1}&frame_no=-1&expr=foo%2B"".join(reversed(foo))'.format(port, debugger_id), method='POST')
+        self.assertEqual(exec_response.body, '"\'123321\'\\n"')
+
+        # clean out the debugger timeout, so the test does not result in an unclean reactor. this is
+        # a lot faster than waiting for the debug_timeout to occur
+        delayed_call = TestRaisingHandler._debugging_timeouts.pop(debugger_id, None)
+        if delayed_call:
+            delayed_call.cancel()
+
+    @defer.inlineCallbacks
+    def test_debugging_allow_list(self):
+        port = self.get_free_port()
+        app = self.get_configured_cyclone(
+            listen = port,
+            application=dict(
+                handlers=[
+                    ('/', reflect.fullyQualifiedName(TestRaisingHandler))
+                ],
+                debug = True,
+                debug_allow = [],
+                debug_timeout = 0 # setting the timeout to 0 means the debugger will disappear right after the request is done.
+            )
+        )
+
+        # start the web application
+        yield self.service.startService()
+
+        response = yield httpclient.fetch('http://localhost:{0}/'.format(port))
+
+        # we should get an error..
+        self.assertEqual(response.code, 500)
+        # .. but should be unable to debug because we're not in the debug_allow list.
+        self.assertNotIn('web.Application Traceback (most recent call last)', response.body)
+        self.assertIn('500: Internal Server Error', response.body)

--- a/contrib/cyclone/piped_cyclone/test/test_cyclone.py
+++ b/contrib/cyclone/piped_cyclone/test/test_cyclone.py
@@ -1,12 +1,14 @@
+# Copyright (c) 2012, Found IT A/S and Piped Project Contributors.
+# See LICENSE for details.
 import re
 import socket
 
 from cyclone import web, httpclient
 from twisted.application import service
 from twisted.internet import defer
-from twisted.python import filepath, reflect, failure
+from twisted.python import filepath, reflect
 from twisted.trial import unittest
-from piped import processing, util
+from piped import processing
 from piped.dependencies import ResourceDependency
 
 from piped_cyclone import providers, handlers

--- a/contrib/cyclone/piped_cyclone/test/test_cyclone.py
+++ b/contrib/cyclone/piped_cyclone/test/test_cyclone.py
@@ -70,6 +70,24 @@ class CycloneProviderTest(unittest.TestCase):
 
         return dependency.get_resource()
 
+    def test_invalid_handlers(self):
+        invalid_handler_configs = [
+            dict(foo='bar'), # missing "handler" and "pattern"
+            dict(handler='bar'), # missing "pattern"
+            dict(pattern='bar'), # missing "handler"
+            dict(handler=set()) # unknown handler type
+        ]
+
+        for invalid_handler_config in invalid_handler_configs:
+            self.assertRaises(providers.InvalidHandlerError, self.get_configured_cyclone,
+                listen=8888,
+                application = dict(
+                    handlers = [
+                        invalid_handler_config
+                    ]
+                )
+            )
+
     @defer.inlineCallbacks
     def test_simple(self):
         port = self.get_free_port()

--- a/contrib/cyclone/setup.py
+++ b/contrib/cyclone/setup.py
@@ -46,6 +46,19 @@ here = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, here)
 import piped_cyclone
 
+
+packages = find_packages(where=here) + ['piped.plugins']
+package_data = {
+    'piped_cyclone': ['templates/debugger.html']
+}
+
+# sdist completely ignores package_data, so we generate a MANIFEST.in
+# http://docs.python.org/distutils/sourcedist.html#specifying-the-files-to-distribute
+with open(os.path.join(here, 'MANIFEST.in'), 'w') as manifest:
+    for package, files in package_data.items():
+        for file in files:
+            manifest.write('include %s \n'%os.path.join(package.replace('.', os.path.sep), file))
+
 setup(
     name = 'piped_cyclone',
     license = 'MIT',
@@ -54,12 +67,9 @@ setup(
     author_email = 'piped@librelist.com',
     url = 'http://piped.io',
 
-    packages = find_packages(where=here) + ['piped.plugins'],
-
+    packages = packages,
     include_package_data = True,
-    package_data = {
-        'piped_cyclone': ['templates/debugger.html']
-    },
+    package_data = package_data,
 
     version = str(piped_cyclone.version),
     classifiers = [

--- a/contrib/cyclone/setup.py
+++ b/contrib/cyclone/setup.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2010-2011, Found IT A/S and Piped Project Contributors.
+# See LICENSE for details.
+import os
+import sys
+
+from setuptools import setup, find_packages
+
+# When pip installs anything from packages, py_modules, or ext_modules that
+# includes a twistd plugin (which are installed to twisted/plugins/),
+# setuptools/distribute writes a Package.egg-info/top_level.txt that includes
+# "twisted".  If you later uninstall Package with `pip uninstall Package`,
+# pip removes all of twisted/ instead of just Package's twistd plugins.  See
+# https://github.com/pypa/pip/issues/355
+#
+# To work around this problem, we monkeypatch
+# setuptools.command.egg_info.write_toplevel_names to not write the line
+# "twisted".  This fixes the behavior of `pip uninstall Package`.  Note that
+# even with this workaround, `pip uninstall Package` still correctly uninstalls
+# Package's twistd plugins from twisted/plugins/, since pip also uses
+# Package.egg-info/installed-files.txt to determine what to uninstall,
+# and the paths to the plugin files are indeed listed in installed-files.txt.
+try:
+    from setuptools.command import egg_info
+    egg_info.write_toplevel_names
+except (ImportError, AttributeError):
+    pass
+else:
+    def _top_level_package(name):
+        return name.split('.', 1)[0]
+
+    def _hacked_write_toplevel_names(cmd, basename, filename):
+        pkgs = dict.fromkeys(
+            [_top_level_package(k)
+                for k in cmd.distribution.iter_distribution_names()
+                if _top_level_package(k) != 'piped'
+            ]
+        )
+        cmd.write_file("top-level names", filename, '\n'.join(pkgs) + '\n')
+
+    egg_info.write_toplevel_names = _hacked_write_toplevel_names
+
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+# add ourselves to the package path so we can get the version from the source tree
+sys.path.insert(0, here)
+import piped_cyclone
+
+setup(
+    name = 'piped_cyclone',
+    license = 'MIT',
+
+    author = 'Piped Project Contributors',
+    author_email = 'piped@librelist.com',
+    url = 'http://piped.io',
+
+    packages = find_packages(where=here) + ['piped.plugins'],
+
+    include_package_data = True,
+    package_data = {
+        'piped_cyclone': ['templates/debugger.html']
+    },
+
+    version = str(piped_cyclone.version),
+    classifiers = [
+        'Development Status :: 4 - Beta',
+        'Environment :: Plugins',
+        'Framework :: Twisted',
+        'Operating System :: OS Independent'
+    ],
+    description = 'Cyclone provider for Piped.',
+
+    install_requires = ['piped', 'cyclone', 'setuptools']
+)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,14 +16,15 @@ Piped documentation
         f -> b
         f -> g
 
-Piped is a `MIT-licensed <https://github.com/foundit/Piped/blob/develop/LICENSE>`_ framework for
+Piped is an `MIT-licensed <https://github.com/foundit/Piped/blob/develop/LICENSE>`_ framework and
+application server with built-in support for
 `flow based programming <http://en.wikipedia.org/wiki/Flow-based_programming>`_ written in Python that focuses on:
 
-* Ease of use.
 * Extendability.
 * Painless integrating with other systems.
 * Testing and maintainability.
 * Performance.
+* Ease of use.
 
 
 A base Piped installation already speaks multiple protocols, such as HTTP, SMTP and Perspective Broker. Contrib packages that extends Piped,

--- a/doc/reference/providers.rst
+++ b/doc/reference/providers.rst
@@ -225,6 +225,17 @@ RPC helpers
     :members:
 
 
+cyclone
+^^^^^^^
+
+.. automodule:: piped_cyclone.providers
+    :members:
+
+.. automodule:: piped_cyclone.handlers
+    :members:
+
+
+
 database
 ^^^^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'Framework :: Twisted',
         'Topic :: Software Development :: Libraries :: Application Frameworks'
     ],
-    description = 'Pipeline processing framework.',
+    description = 'A framework and application server with pipelines.',
     long_description = """
         See http://piped.io for more details.
     """,


### PR DESCRIPTION
Added support for cyclone.

RequestHandlers can be depended on and used as resources, pipelines can be used to process requests (requests are not closed when they are garbage collected, as in the regular web-provider, however) and any named RequestHandler classes can be used. If the named RequestHandler classes has a .configure(runtime_environment) classmethod, it will be called when the cyclone.web.Application is created. See the piped_cyclone.providers.CycloneProvider docstring for more details.

Also includes debugging support.
