### PR TITLE
Timeouts

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,9 @@ Features:
       For more information about strports, see
       http://twistedmatrix.com/documents/current/api/twisted.application.strports.html
 
+    - It is now possible to check whether a "piped.dependencies.DependencyMap" contains
+      a dependency (which may or may not currently be available) by using the "in"
+      operator.
 
 New processors:
     - get-zookeeper-children: Get a list of children for a ZooKeeper node.
@@ -73,6 +76,9 @@ Backward-incompatible changes:
         they used code from the twisted test suite, which shouldn't be used in
         production. They might come back at a later time, but no time-frame can
         be given at this moment.
+
+    - "piped.dependencies.DependencyMap.__in__" has been removed. Use
+      ".is_available" instead.
 
 Bug fixes:
     - #21: When tracing, if a processor asynchronously raised an exception,

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,6 +31,16 @@ Features:
       a dependency (which may or may not currently be available) by using the "in"
       operator.
 
+    - "piped.event.Event.wait_until_fired()" now takes an optional "timeout" argument.
+      If the event has not fired before the timeout is reached, a
+      "piped.exceptions.TimeoutError" is raised. The default timeout of ``None`` means
+      no timeout.
+
+    - "InstanceDependency", "ResourceDependency" and "DependencyMap" in
+      "piped.dependencies" now has support for a timeout keyword argument to
+      ".wait_for_resource()". If the resource is not available before the timeout
+      is reached, a "piped.exceptions.TimeoutError" is raised.
+
 New processors:
     - get-zookeeper-children: Get a list of children for a ZooKeeper node.
     - get-zookeeper-data: Get the data of a ZooKeeper node.
@@ -72,6 +82,7 @@ Backward-incompatible changes:
               foo: bar
 
          instead.
+
     - The processors proxy-forward and chain-web-requests were removed because
         they used code from the twisted test suite, which shouldn't be used in
         production. They might come back at a later time, but no time-frame can

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 This is the MIT license: http://www.opensource.org/licenses/mit-license.php
 
-Copyright (c) 2010-2011, Found IT A/S and Piped Project Contributors.
+Copyright (c) 2010-2012, Found IT A/S and Piped Project Contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/piped/test/test_dependencies.py
+++ b/piped/test/test_dependencies.py
@@ -26,6 +26,14 @@ class DependencyManagerTest(unittest.TestCase):
         self.assertRaises(exceptions.UnsatisfiedDependencyError, getattr, dependency_map, 'should_be_unavailable')
         self.assertRaises(AttributeError, getattr, dependency_map, 'nonexisting')
 
+    def test_dependency_map_in(self):
+        consumer = object()
+        resource_dependency = dependencies.ResourceDependency(provider='unavailable', manager=self.dependency_manager)
+        dependency_map = self.dependency_manager.create_dependency_map(consumer, should_be_unavailable=resource_dependency)
+
+        self.assertIn('should_be_unavailable', dependency_map)
+        self.assertNotIn('nonexisting', dependency_map)
+
     def test_accessing_provided_dependency(self):
         # Consumer wants fake_resource, but it's not directly
         # available as an instance. It's provided by a provider which

--- a/piped/test/test_event.py
+++ b/piped/test/test_event.py
@@ -1,9 +1,9 @@
-# Copyright (c) 2010-2011, Found IT A/S and Piped Project Contributors.
+# Copyright (c) 2010-2012, Found IT A/S and Piped Project Contributors.
 # See LICENSE for details.
 from twisted.internet import defer
 from twisted.trial import unittest
 
-from piped import event
+from piped import event, util, exceptions
 
 
 class TestEvent(unittest.TestCase):
@@ -54,6 +54,24 @@ class TestEvent(unittest.TestCase):
         args, kwargs = yield d
         self.assertEquals(args, ('foo',))
         self.assertEquals(kwargs, dict(bar='baz'))
+
+    @defer.inlineCallbacks
+    def test_wait_until_fired_timeout(self):
+        e = event.Event()
+
+        d = e.wait_until_fired(timeout=0)
+        self.assertFalse(d.called)
+
+        # the deferred should be errbacked if the timeout is reached:
+        yield util.wait(0)
+
+        self.assertTrue(d.called)
+
+        try:
+            yield d
+            self.fail('TimeoutError not raised.')
+        except exceptions.TimeoutError as te:
+            pass
 
 
 __doctests__ = [event]

--- a/piped/test/test_event.py
+++ b/piped/test/test_event.py
@@ -73,5 +73,21 @@ class TestEvent(unittest.TestCase):
         except exceptions.TimeoutError as te:
             pass
 
+    @defer.inlineCallbacks
+    def test_delayed_call_is_cancelled(self):
+        e = event.Event()
+
+        d = e.wait_until_fired(timeout=1)
+
+        e('foo')
+
+        foo = yield d
+        self.assertEquals(foo, (('foo',), {}))
+
+        # since we called wait_until_fired with a timeout, a timeout was created, but the event
+        # was fired before the timeout was reached. In this case, the timeout delayed call should
+        # have been cancelled. If it is not cancelled, this test will fail with a
+        # DirtyReactorAggregateError.
+
 
 __doctests__ = [event]


### PR DESCRIPTION
Features:

```
- It is now possible to check whether a "piped.dependencies.DependencyMap" contains
  a dependency (which may or may not currently be available) by using the "in"
  operator.

- "piped.event.Event.wait_until_fired()" now takes an optional "timeout" argument.
  If the event has not fired before the timeout is reached, a
  "piped.exceptions.TimeoutError" is raised. The default timeout of ``None`` means
  no timeout.

- "InstanceDependency", "ResourceDependency" and "DependencyMap" in
  "piped.dependencies" now has support for a timeout keyword argument to
  ".wait_for_resource()". If the resource is not available before the timeout
  is reached, a "piped.exceptions.TimeoutError" is raised.
```

Backwards incompatible

```
- "piped.dependencies.DependencyMap.__in__" has been removed. Use
  ".is_available" instead.
```

**in** bears no special meaning in python, and we probably meant to use **contains** instead, and I think that **contains** should check whether the dependency map contains the dependency, not whether it is actually available, which can be checked via "is_available" anyway.
