### PR TITLE
Postgres listener improvements

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,15 @@
 ================================ Next release ================================
 
+Backward-incompatible changes:
+    piped.contrib.database's SerialPostgresListenerService is removed.
+    The remaining PostgresListenerService is also simpler, not caring about
+    txid_min thresholds.
+
+Bug fixes:
+    - Reconnect Postgres listeners more reliably.
+    - Don't cause multiple run_as_leader run-loops to be spawned on certain
+      reconnects.
+
 ========================== Release 0.6.0 2015-02-20 ==========================
 
 Features:

--- a/contrib/database/piped_database/db.py
+++ b/contrib/database/piped_database/db.py
@@ -160,8 +160,7 @@ class EngineManager(piped_service.PipedService):
         if not self.engine_configuration.get('url'):
             raise exceptions.ConfigurationError('missing database-URL')
         if not self.ping_interval:
-            detail = 'currently set to [{0!r}]'.format(configuration['ping_interval'])
-            raise exceptions.ConfigurationError('Please specify a non-zero ping-interval', detail)
+            raise exceptions.ConfigurationError('Please specify a non-zero ping-interval')
 
     @defer.inlineCallbacks
     def run(self):

--- a/contrib/database/piped_database/service.py
+++ b/contrib/database/piped_database/service.py
@@ -78,11 +78,12 @@ class PostgresListenerService(service.PipedDependencyService):
     @defer.inlineCallbacks
     def run_as_leader(self):
         logger.info('Running as leader for service [{0}]'.format(self.service_name))
-        notification_queue = yield self.listener.listen(self.channels)
-
-        yield self.process_initial()
 
         try:
+            notification_queue = yield self.listener.listen(self.channels)
+
+            yield self.process_initial()
+
             while self.running:
                 event = yield self.cancellable(notification_queue.get())
 
@@ -115,91 +116,3 @@ class PostgresListenerService(service.PipedDependencyService):
 
     def get_payload(self, event):
         return json.loads(event.payload)
-
-
-class SerialPostgresListenerService(PostgresListenerService):
-    """Like PostgresListenerService, but invokes handlers for
-    notifications strictly in order of transaction IDs.
-
-    This comes with caveats, some of which are described above --- but
-    the approach is nice if you need to keep things in sync, as resync
-    can be done reliably wrt. to the highest txid on the other end.
-
-    Expects notification payloads to contain `txid` and `txid_min`,
-    where `txid_min` is the current minimum visible transaction.
-
-    Long-running transactions will block the processing of subsequent
-    events. Note that this is true regardless of which database the
-    transaction is happening in, as transaction IDs are global for a
-    Postgres-cluster. Therefore, be careful using this approach if you
-    cannot control long running transactions.
-
-    Queued notifications are kept in memory, without any bounds. Thus,
-    a long-running transaction blocking a large number of other
-    notifications will cause memory issues.
-
-    """
-
-    @defer.inlineCallbacks
-    def run_as_leader(self):
-        logger.info('Running as leader for service [{0}]'.format(self.service_name))
-        try:
-            notification_queue = yield self.listener.listen(self.channels)
-
-            yield self.process_initial()
-        
-            notify_queue = []
-            listener = self.listener
-            
-            while self.running:
-                if notify_queue:
-                    # If we have events we have not emitted yet, we can't just hope for another notification,
-                    # we must also poll for txid --- because the long-running transaction that is blocking us
-                    # can be totally unrelated, and thus not result in any notification. It can take a long
-                    # time until another notification comes. Thus, poll a bit - and when we're safe, flush
-                    # the queue up to the new threshold.
-
-                    # TODO: We can piggyback on notifications as well,
-                    # but then we'll have to consider requeuing it and
-                    # so on. Keep it simple for now by going into polling-mode when waiting.
-
-                    current_minimum_txid = yield self.cancellable(
-                        listener.wait_for_txid_min(notify_queue[0][0])
-                    )
-                else:
-                    notification = yield self.cancellable(notification_queue.get())
-
-                    try:
-                        payload = self.get_payload(notification)
-                    except (ValueError, TypeError):
-                        continue
-                    
-                    notification = (notification.channel, payload)
-
-                    try:
-                        current_minimum_txid = payload['txid_min']
-                        heapq.heappush(notify_queue, (payload['txid'], notification))
-                    except KeyError:
-                        logger.error('invalid notification without txids received: [{0}]'.format(notification))
-
-                while self.running and notify_queue and notify_queue[0][0] <= current_minimum_txid:
-                    try:
-                        notification = heapq.heappop(notify_queue)[1]
-                        yield self._handle_notification(notification)
-                    except Exception:
-                        logger.exception('error handling notification [{0}]'.format(notification))
-
-        except defer.CancelledError:
-            pass
-
-        finally:
-            self.listener.unlisten(notification_queue)
-
-    def _handle_notification(self, notification):
-        channel, payload = notification
-        handler = self.get_handler(channel)
-        if not handler:
-            logger.warn('no handler for event [{0}]'.format(channel))
-            return
-
-        return handler(payload)

--- a/contrib/database/piped_database/service.py
+++ b/contrib/database/piped_database/service.py
@@ -1,13 +1,10 @@
-import datetime
-import heapq
-import json
 import logging
-import random
+import json
+import os
 
-import sqlalchemy as sa
-from piped import exceptions, service, util
-from piped import service as piped_service
-from twisted.internet import defer, reactor
+from twisted.internet import defer
+
+from piped import service, util
 
 
 logger = logging.getLogger('piped_database.service')

--- a/contrib/database/piped_database/test/test_database.py
+++ b/contrib/database/piped_database/test/test_database.py
@@ -107,7 +107,6 @@ class EngineProviderTest(unittest.TestCase):
             mock.call.connection(),
             mock.call.connection().execute("SELECT 'ping'"),
             mock.call.connection().close(),
-            mock.call.engine.dispose(), # and disposed when the service stops.
             mock.call.engine.dispose() # and disposed when the service stops.
         ])
 


### PR DESCRIPTION
Remove SerialPostgresListenerService: The same can be achieved a lot simpler by simply not exposing txids larger than txid_min to external things we possibly resync from.

Make reconnecting the Postgres listeners more reliable.
